### PR TITLE
[feat] Add feedback comment for chat-ops

### DIFF
--- a/pkg/chatops/errors.go
+++ b/pkg/chatops/errors.go
@@ -1,0 +1,12 @@
+package chatops
+
+import "fmt"
+
+type unauthorizedError struct {
+	user string
+	repo string
+}
+
+func (e *unauthorizedError) Error() string {
+	return fmt.Sprintf("%s is not authorized for %s", e.user, e.repo)
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -20,7 +20,19 @@ type Client interface {
 	// Users
 	GetUserInfo(user string) (*User, error)
 	CanUserWriteToRepo(user User) (bool, error)
+
+	// Comments
+	RegisterComment(issueType IssueType, issueNo int, body string) error
 }
+
+// IssueType is a type of the issue
+type IssueType string
+
+// IssueType constants
+const (
+	IssueTypeIssue       = IssueType("issue")
+	IssueTypePullRequest = IssueType("pull_request")
+)
 
 // CommitStatusState is a commit status type
 type CommitStatusState string

--- a/pkg/git/github/github.go
+++ b/pkg/git/github/github.go
@@ -159,6 +159,17 @@ func (c *Client) CanUserWriteToRepo(user git.User) (bool, error) {
 	return permission.Permission == "admin" || permission.Permission == "write", nil
 }
 
+// RegisterComment registers comment to an issue
+func (c *Client) RegisterComment(_ git.IssueType, issueNo int, body string) error {
+	apiUrl := fmt.Sprintf("%s/repos/%s/issues/%d/comments", c.IntegrationConfig.Spec.Git.GetAPIUrl(), c.IntegrationConfig.Spec.Git.Repository, issueNo)
+
+	commentBody := &CommentBody{Body: body}
+	if _, _, err := c.requestHTTP(http.MethodPost, apiUrl, commentBody); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *Client) getPullRequestInfo(id int) (*git.PullRequest, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/pulls/%d", c.IntegrationConfig.Spec.Git.GetAPIUrl(), c.IntegrationConfig.Spec.Git.Repository, id)
 
@@ -177,7 +188,7 @@ func (c *Client) getPullRequestInfo(id int) (*git.PullRequest, error) {
 
 func convertPullRequestToShared(pr *PullRequest) *git.PullRequest {
 	return &git.PullRequest{
-		ID:    pr.ID,
+		ID:    pr.Number,
 		Title: pr.Title,
 		State: git.PullRequestState(pr.State),
 		Sender: git.User{

--- a/pkg/git/github/github_types.go
+++ b/pkg/git/github/github_types.go
@@ -19,3 +19,8 @@ type CommitStatusBody struct {
 	Description string `json:"description"`
 	Context     string `json:"context"`
 }
+
+// CommentBody is a body structure for creating new comment
+type CommentBody struct {
+	Body string `json:"body"`
+}

--- a/pkg/git/github/webhook.go
+++ b/pkg/git/github/webhook.go
@@ -67,12 +67,12 @@ type Repo struct {
 
 // PullRequest is a pull request info
 type PullRequest struct {
-	Title string `json:"title"`
-	ID    int    `json:"id"`
-	State string `json:"state"`
-	URL   string `json:"html_url"`
-	User  User   `json:"user"`
-	Head  struct {
+	Title  string `json:"title"`
+	Number int    `json:"number"`
+	State  string `json:"state"`
+	URL    string `json:"html_url"`
+	User   User   `json:"user"`
+	Head   struct {
 		Ref string `json:"ref"`
 		Sha string `json:"sha"`
 	} `json:"head"`

--- a/pkg/git/gitlab/gitlab_types.go
+++ b/pkg/git/gitlab/gitlab_types.go
@@ -20,3 +20,8 @@ type CommitStatusBody struct {
 	Description string `json:"description"`
 	Context     string `json:"context"`
 }
+
+// CommentBody is a body structure for creating new comment
+type CommentBody struct {
+	Body string `json:"body"`
+}


### PR DESCRIPTION
- Register 'Unauthorized' message comment if chat-ops sender is not an author of the pull request and does not have write permission on the repository