### PR TITLE
[fix] Change ingress controller as a real controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,6 +52,7 @@ data:
   collectPeriod: "120"
   integrationJobTTL: "120"
   ingressClass: ""
+  ingressHost: ""
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/config/release.yaml
+++ b/config/release.yaml
@@ -52,6 +52,7 @@ data:
   collectPeriod: "120"
   integrationJobTTL: "120"
   ingressClass: ""
+  ingressHost: ""
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/controllers/configmap_controller.go
+++ b/controllers/configmap_controller.go
@@ -164,6 +164,7 @@ func (r *ConfigReconciler) reconcileConfig(cm *corev1.ConfigMap) error {
 		"collectPeriod":             {Type: cfgTypeInt, IntVal: &configs.CollectPeriod, IntDefault: 120},        // GC period
 		"integrationJobTTL":         {Type: cfgTypeInt, IntVal: &configs.IntegrationJobTTL, IntDefault: 120},    // GC threshold
 		"ingressClass":              {Type: cfgTypeString, StringVal: &configs.IngressClass, StringDefault: ""}, // Ingress class
+		"ingressHost":               {Type: cfgTypeString, StringVal: &configs.IngressHost, StringDefault: ""},  // Ingress host
 	}
 
 	getVars(cm.Data, vars)

--- a/controllers/ingress_controller.go
+++ b/controllers/ingress_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
 	"github.com/tmax-cloud/cicd-operator/internal/configs"
 	"github.com/tmax-cloud/cicd-operator/internal/utils"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
@@ -11,85 +12,152 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/typed/networking/v1beta1"
 	"k8s.io/kubernetes/pkg/apis/core"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	ingName = "cicd-webhook"
 )
 
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=get;update;patch
 
-// WaitIngressReady waits until ingress is ready (i.e., loadbalancer ip is set)
-func WaitIngressReady() error {
-	log := ctrl.Log.WithName("ingress-controller")
+// IngressController is an interface for ingress controller
+type IngressController interface {
+	Wait() error
+	Start()
+}
 
+type ingressController struct {
+	initiated           bool
+	initCh              chan error
+	lastResourceVersion string
+
+	ingCli v1beta1.IngressInterface
+
+	log logr.Logger
+}
+
+// NewIngressController instantiates ingressController
+func NewIngressController() IngressController {
+	return &ingressController{
+		initiated:           false,
+		initCh:              make(chan error),
+		lastResourceVersion: "",
+		log:                 ctrl.Log.WithName("ingress-controller"),
+	}
+}
+
+func (i *ingressController) Wait() error {
+	if i.initiated {
+		return nil
+	}
+	return <-i.initCh
+}
+
+func (i *ingressController) Start() {
+	// Initiate client
 	ingCli, err := newIngressClient()
 	if err != nil {
-		return err
+		i.log.Error(err, "")
+		os.Exit(1)
+	}
+	i.ingCli = ingCli
+
+	// Get first to check the Ingress's existence
+	_, err = i.ingCli.Get(context.Background(), ingName, metav1.GetOptions{})
+	if err != nil {
+		i.log.Error(err, "")
+		os.Exit(1)
 	}
 
-	watcher, err := ingCli.Watch(context.Background(), metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(core.ObjectNameField, "cicd-webhook").String(),
+	for {
+		i.watch()
+	}
+}
+
+func (i *ingressController) watch() {
+	watcher, err := i.ingCli.Watch(context.Background(), metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(core.ObjectNameField, ingName).String(),
 	})
 	if err != nil {
-		return err
+		i.log.Error(err, "")
+		return
 	}
 
 	for result := range watcher.ResultChan() {
 		ing, ok := result.Object.(*networkingv1beta1.Ingress)
-		if !ok {
-			return fmt.Errorf("watch result is not an ingress")
-		}
-
-		log.Info(ing.Name)
-
-		// Check if class is set properly
-		class := ing.Annotations[networkingv1beta1.AnnotationIngressClass]
-		if class != configs.IngressClass {
-			log.Info("Updating ingress with proper class...")
-			ing.Annotations[networkingv1beta1.AnnotationIngressClass] = configs.IngressClass
-			if _, err := ingCli.Update(context.Background(), ing, metav1.UpdateOptions{}); err != nil {
-				return err
+		if ok && i.lastResourceVersion != ing.ResourceVersion {
+			i.lastResourceVersion = ing.ResourceVersion
+			if err := i.reconcile(ing); err != nil {
+				i.log.Error(err, "")
 			}
-			continue
-		}
-
-		// IP is set
-		if len(ing.Status.LoadBalancer.Ingress) > 0 && ing.Status.LoadBalancer.Ingress[0].IP != "" {
-			ip := ing.Status.LoadBalancer.Ingress[0].IP
-
-			// Check if host is already set
-			if len(ing.Spec.Rules) == 0 {
-				return fmt.Errorf("rules for ingress are not set")
-			}
-
-			// Host is already set
-			if ing.Spec.Rules[0].Host != "waiting.for.loadbalancer" {
-				if configs.ExternalHostName == "" {
-					configs.ExternalHostName = ing.Spec.Rules[0].Host
-				}
-				return nil
-			}
-
-			// If not, set it!
-			hostname := configs.ExternalHostName
-			if configs.ExternalHostName == "" {
-				hostname = fmt.Sprintf("cicd-webhook.%s.nip.io", ip)
-			}
-			ing.Spec.Rules[0].Host = hostname
-
-			if _, err := ingCli.Update(context.Background(), ing, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-
-			if configs.ExternalHostName == "" {
-				configs.ExternalHostName = hostname
-			}
-
-			return nil
 		}
 	}
+}
 
-	return fmt.Errorf("cannot wait ingress ready")
+func (i *ingressController) reconcile(ing *networkingv1beta1.Ingress) error {
+	i.log.Info(fmt.Sprintf("Reconciling ingress %s", ing.Name))
+	// Check if class is set properly
+	class := ing.Annotations[networkingv1beta1.AnnotationIngressClass]
+	if class != configs.IngressClass {
+		i.log.Info("Updating ingress with proper class...")
+		ing.Annotations[networkingv1beta1.AnnotationIngressClass] = configs.IngressClass
+		if _, err := i.ingCli.Update(context.Background(), ing, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// IP is set
+	if len(ing.Status.LoadBalancer.Ingress) > 0 && ing.Status.LoadBalancer.Ingress[0].IP != "" {
+		ip := ing.Status.LoadBalancer.Ingress[0].IP
+
+		// Check if host is already set
+		if len(ing.Spec.Rules) == 0 {
+			return fmt.Errorf("rules for ingress are not set")
+		}
+
+		// Host is already set
+		if ing.Spec.Rules[0].Host != "waiting.for.loadbalancer" {
+			if configs.ExternalHostName == "" {
+				configs.ExternalHostName = ing.Spec.Rules[0].Host
+			}
+
+			i.log.Info("Current external hostname is " + configs.ExternalHostName)
+			if !i.initiated {
+				i.initiated = true
+				i.initCh <- nil
+			}
+			return nil
+		}
+
+		// If not, set it!
+		hostname := configs.IngressHost
+		if hostname == "" {
+			hostname = fmt.Sprintf("cicd-webhook.%s.nip.io", ip)
+		}
+		ing.Spec.Rules[0].Host = hostname
+
+		if _, err := i.ingCli.Update(context.Background(), ing, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+
+		if configs.ExternalHostName == "" {
+			configs.ExternalHostName = hostname
+		}
+
+		i.log.Info("Current external hostname is " + configs.ExternalHostName)
+		if !i.initiated {
+			i.initiated = true
+			i.initCh <- nil
+		}
+		return nil
+	}
+
+	return nil
 }
 
 func newIngressClient() (v1beta1.IngressInterface, error) {

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -40,4 +40,7 @@ var (
 
 	// IngressClass is a class for ingress instance
 	IngressClass string
+
+	// IngressHost is a host for ingress instance
+	IngressHost string
 )

--- a/main.go
+++ b/main.go
@@ -168,8 +168,10 @@ func main() {
 
 	// Check for ingress first
 	setupLog.Info("Waiting for ingress to be ready")
-	if err := controllers.WaitIngressReady(); err != nil {
-		setupLog.Error(err, "error while waiting ingress ready")
+	ingCon := controllers.NewIngressController()
+	go ingCon.Start()
+	if err := ingCon.Wait(); err != nil {
+		setupLog.Error(err, "error waiting for ingress")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Ingress controller was originally meant to make sure an ingress for the
webhook server is ready before running the server.

Now it reconciles Ingress so that it can handle the change of the
Ingress while operating.