### PR TITLE
[feat] Enable manual trigger of IntegrationConfig's jobs

### DIFF
--- a/api/v1/git_types.go
+++ b/api/v1/git_types.go
@@ -39,6 +39,8 @@ func (config *GitConfig) GetGitHost() (string, error) {
 	gitURL := config.GetAPIUrl()
 	if gitURL == GithubDefaultAPIUrl {
 		gitURL = GithubDefaultHost
+	} else if gitURL == GitlabDefaultAPIUrl {
+		gitURL = GitlabDefaultHost
 	}
 	gitU, err := url.Parse(gitURL)
 	if err != nil {

--- a/pkg/apiserver/apis/v1/integrationconfigs/integrationconfigs.go
+++ b/pkg/apiserver/apis/v1/integrationconfigs/integrationconfigs.go
@@ -1,0 +1,60 @@
+package integrationconfigs
+
+import (
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/tmax-cloud/cicd-operator/internal/apiserver"
+	"github.com/tmax-cloud/cicd-operator/internal/utils"
+	"github.com/tmax-cloud/cicd-operator/internal/wrapper"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// APIVersion of the api
+	APIVersion = "v1"
+
+	// ICKind is a kind string of IntegrationConfigs
+	ICKind     = "integrationconfigs"
+	icParamKey = "icName"
+)
+
+type handler struct {
+	k8sClient client.Client
+	log       logr.Logger
+
+	authorizer apiserver.Authorizer
+}
+
+// NewHandler instantiates a new integration configs api handler
+func NewHandler(parent wrapper.RouterWrapper, cli client.Client, logger logr.Logger) (apiserver.APIHandler, error) {
+	handler := &handler{k8sClient: cli, log: logger}
+
+	// Authorizer
+	authClient, err := utils.AuthClient()
+	if err != nil {
+		return nil, err
+	}
+	handler.authorizer = apiserver.NewAuthorizer(authClient, apiserver.APIGroup, APIVersion, "create")
+
+	// /integrationconfigs/<integrationconfig>
+	icWrapper := wrapper.New(fmt.Sprintf("/%s/{%s}", ICKind, icParamKey), nil, nil)
+	if err := parent.Add(icWrapper); err != nil {
+		return nil, err
+	}
+	icWrapper.Router().Use(handler.authorizer.Authorize)
+
+	// /integrationconfigs/<integrationconfig>/runpre
+	runPreWrapper := wrapper.New("/runpre", []string{http.MethodPost}, handler.runPreHandler)
+	if err := icWrapper.Add(runPreWrapper); err != nil {
+		return nil, err
+	}
+
+	// /integrationconfigs/<integrationconfig>/runpost
+	runPostWrapper := wrapper.New("/runpost", []string{http.MethodPost}, handler.runPostHandler)
+	if err := icWrapper.Add(runPostWrapper); err != nil {
+		return nil, err
+	}
+
+	return handler, nil
+}

--- a/pkg/apiserver/apis/v1/integrationconfigs/run.go
+++ b/pkg/apiserver/apis/v1/integrationconfigs/run.go
@@ -1,0 +1,167 @@
+package integrationconfigs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/gorilla/mux"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/internal/apiserver"
+	"github.com/tmax-cloud/cicd-operator/internal/utils"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	"github.com/tmax-cloud/cicd-operator/pkg/server"
+	"io"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"regexp"
+)
+
+const (
+	defaultBranch = "master"
+)
+
+type bodyReqPost struct {
+	Branch string `json:"branch"`
+}
+
+type bodyReqPre struct {
+	BaseBranch string `json:"base_branch"`
+	HeadBranch string `json:"head_branch"`
+}
+
+func (h *handler) runPreHandler(w http.ResponseWriter, req *http.Request) {
+	h.runHandler(w, req, git.EventTypePullRequest)
+}
+
+func (h *handler) runPostHandler(w http.ResponseWriter, req *http.Request) {
+	h.runHandler(w, req, git.EventTypePush)
+}
+
+func (h *handler) runHandler(w http.ResponseWriter, req *http.Request, et git.EventType) {
+	reqID := utils.RandomString(10)
+	log := h.log.WithValues("request", reqID)
+
+	// Get ns/approvalName
+	vars := mux.Vars(req)
+
+	ns, nsExist := vars[apiserver.NamespaceParamKey]
+	resName, nameExist := vars[icParamKey]
+	if !nsExist || !nameExist {
+		_ = utils.RespondError(w, http.StatusBadRequest, "url is malformed")
+		return
+	}
+
+	// Get user
+	user, err := apiserver.GetUserName(req.Header)
+	if err != nil {
+		log.Info(err.Error())
+		_ = utils.RespondError(w, http.StatusUnauthorized, fmt.Sprintf("req: %s, forbidden user, err : %s", reqID, err.Error()))
+		return
+	}
+	userEscaped := regexp.MustCompile("[^-A-Za-z0-9_.]").ReplaceAllString(user, "_")
+
+	// Get IntegrationConfig
+	ic := &cicdv1.IntegrationConfig{}
+	if err := h.k8sClient.Get(context.Background(), types.NamespacedName{Name: resName, Namespace: ns}, ic); err != nil {
+		log.Info(err.Error())
+		_ = utils.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("req: %s, cannot get IntegrationConfig %s/%s", reqID, ns, resName))
+		return
+	}
+
+	gitHost, err := ic.Spec.Git.GetGitHost()
+	if err != nil {
+		log.Info(err.Error())
+		_ = utils.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("req: %s, cannot get IntegrationConfig %s/%s's git host", reqID, ns, resName))
+		return
+	}
+
+	// Build webhook
+	wh := &git.Webhook{
+		EventType: et,
+		Repo: git.Repository{
+			Name: ic.Spec.Git.Repository,
+			URL:  fmt.Sprintf("%s/%s", gitHost, ic.Spec.Git.Repository),
+		},
+	}
+
+	switch et {
+	case git.EventTypePullRequest:
+		pr, err := buildPullRequestWebhook(req.Body, userEscaped)
+		if err != nil {
+			log.Info(err.Error())
+			_ = utils.RespondError(w, http.StatusBadRequest, fmt.Sprintf("req: %s, cannot build pull_request webhook", reqID))
+			return
+		}
+		wh.PullRequest = pr
+	case git.EventTypePush:
+		push, err := buildPushWebhook(req.Body, userEscaped)
+		if err != nil {
+			log.Info(err.Error())
+			_ = utils.RespondError(w, http.StatusBadRequest, fmt.Sprintf("req: %s, cannot build push webhook", reqID))
+			return
+		}
+		wh.Push = push
+	}
+
+	// Trigger Run!
+	if err := server.HandleEvent(wh, ic); err != nil {
+		log.Info(err.Error())
+		_ = utils.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("req: %s, cannot handle event, err : %s", reqID, err.Error()))
+		return
+	}
+
+	_ = utils.RespondJSON(w, struct{}{})
+}
+
+func buildPullRequestWebhook(body io.ReadCloser, user string) (*git.PullRequest, error) {
+	userReq := &bodyReqPre{}
+	decoder := json.NewDecoder(body)
+	if err := decoder.Decode(userReq); err != nil {
+		return nil, err
+	}
+
+	baseBranch := userReq.BaseBranch
+	headBranch := userReq.HeadBranch
+	if baseBranch == "" {
+		baseBranch = defaultBranch
+	}
+	if headBranch == "" {
+		return nil, fmt.Errorf("head_branch must be set")
+	}
+
+	return &git.PullRequest{
+		State:  git.PullRequestStateOpen,
+		Action: git.PullRequestActionOpen,
+		Sender: git.User{
+			Name: fmt.Sprintf("trigger-%s-end", user),
+		},
+		Base: git.Base{
+			Ref: baseBranch,
+		},
+		Head: git.Head{
+			Ref: headBranch,
+			Sha: git.FakeSha,
+		},
+	}, nil
+}
+
+func buildPushWebhook(body io.ReadCloser, user string) (*git.Push, error) {
+	userReq := &bodyReqPost{}
+	decoder := json.NewDecoder(body)
+	if err := decoder.Decode(userReq); err != nil {
+		return nil, err
+	}
+
+	branch := userReq.Branch
+	if branch == "" {
+		branch = defaultBranch
+	}
+
+	return &git.Push{
+		Sender: git.User{
+			Name: fmt.Sprintf("trigger-%s-end", user),
+		},
+		Ref: branch,
+		Sha: git.FakeSha,
+	}, nil
+}

--- a/pkg/apiserver/apis/v1/integrationconfigs/run_test.go
+++ b/pkg/apiserver/apis/v1/integrationconfigs/run_test.go
@@ -1,0 +1,155 @@
+package integrationconfigs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/bmizerany/assert"
+	"github.com/gorilla/mux"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/internal/apiserver"
+	"github.com/tmax-cloud/cicd-operator/pkg/chatops"
+	"github.com/tmax-cloud/cicd-operator/pkg/dispatcher"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	"github.com/tmax-cloud/cicd-operator/pkg/server"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type assertFunc func(*cicdv1.IntegrationJob)
+
+func Test_handler_runPreHandler(t *testing.T) {
+	h, err := initTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TEST 1
+	testReq(t, h, bodyReqPre{HeadBranch: "newnew"}, "runpre", func(job *cicdv1.IntegrationJob) {
+		assert.Equal(t, true, job.Spec.Refs.Pull != nil, "refs.pr is not nil")
+		assert.Equal(t, "newnew", job.Spec.Refs.Pull.Ref, "pr.ref")
+	})
+
+	// TEST 2
+	testReq(t, h, bodyReqPre{HeadBranch: "newnew", BaseBranch: "new"}, "runpre", func(job *cicdv1.IntegrationJob) {
+		assert.Equal(t, "new", job.Spec.Refs.Base.Ref, "base.ref")
+		assert.Equal(t, true, job.Spec.Refs.Pull != nil, "refs.pr is not nil")
+		assert.Equal(t, "newnew", job.Spec.Refs.Pull.Ref, "pr.ref")
+	})
+}
+
+func Test_handler_runPostHandler(t *testing.T) {
+	h, err := initTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TEST 1
+	testReq(t, h, bodyReqPost{}, "runpost", func(job *cicdv1.IntegrationJob) {
+		assert.Equal(t, "master", job.Spec.Refs.Base.Ref, "base ref")
+		assert.Equal(t, true, job.Spec.Refs.Pull == nil, "ref.pr is nil")
+	})
+
+	// TEST 2
+	testReq(t, h, bodyReqPost{Branch: "new"}, "runpost", func(job *cicdv1.IntegrationJob) {
+		assert.Equal(t, "new", job.Spec.Refs.Base.Ref, "base ref")
+		assert.Equal(t, true, job.Spec.Refs.Pull == nil, "ref.pr is nil")
+	})
+}
+
+func initTestEnv() (*handler, error) {
+	s := runtime.NewScheme()
+	utilruntime.Must(cicdv1.AddToScheme(s))
+
+	ic := &cicdv1.IntegrationConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: cicdv1.IntegrationConfigSpec{
+			Git: cicdv1.GitConfig{
+				Type:       "github",
+				Repository: "tmax-cloud/cicd-operator",
+			},
+			Jobs: cicdv1.IntegrationConfigJobs{
+				PreSubmit: cicdv1.Jobs{{
+					Container: corev1.Container{
+						Name:  "pre-test",
+						Image: "test-img",
+					},
+				}},
+				PostSubmit: cicdv1.Jobs{{
+					Container: corev1.Container{
+						Name:  "post-test",
+						Image: "test-img",
+					},
+				}},
+			},
+		},
+	}
+	fakeCli := fake.NewFakeClientWithScheme(s, ic)
+
+	h := &handler{
+		k8sClient: fakeCli,
+		log:       logf.Log,
+	}
+
+	server.AddPlugin([]git.EventType{git.EventTypePullRequest, git.EventTypePush}, &dispatcher.Dispatcher{Client: h.k8sClient})
+	server.AddPlugin([]git.EventType{git.EventTypeIssueComment}, chatops.New(h.k8sClient))
+
+	return h, nil
+}
+
+func testReq(t *testing.T, h *handler, body interface{}, subresource string, assertFunc assertFunc) {
+	req, w := newTestReq(body, subresource)
+	switch subresource {
+	case "runpost":
+		h.runPostHandler(w, req)
+	case "runpre":
+		h.runPreHandler(w, req)
+	default:
+		t.Fatal("subresource " + subresource + " is not supported")
+	}
+	list := &cicdv1.IntegrationJobList{}
+	if err := h.k8sClient.List(context.Background(), list); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 200, w.Code, "response code")
+	assert.Equal(t, 1, len(list.Items), "ij length")
+
+	assert.Equal(t, "tmax-cloud/cicd-operator", list.Items[0].Spec.Refs.Repository, "repository")
+	assert.Equal(t, "https://github.com/tmax-cloud/cicd-operator", list.Items[0].Spec.Refs.Base.Link, "refs.base link")
+	assert.Equal(t, "trigger-system_serviceaccount_default_admin-end", list.Items[0].Spec.Refs.Sender.Name, "sender name")
+	assert.Equal(t, "https://github.com/tmax-cloud/cicd-operator", list.Items[0].Spec.Refs.Link, "refs link")
+
+	if assertFunc != nil {
+		assertFunc(&list.Items[0])
+	}
+
+	if err := h.k8sClient.Delete(context.Background(), &list.Items[0]); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestReq(body interface{}, subresource string) (*http.Request, *httptest.ResponseRecorder) {
+	var buf bytes.Buffer
+	b, _ := json.Marshal(body)
+	buf.Write(b)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/apis/cicdapi.tmax.io/v1/namespaces/default/integrationconfigs/test/"+subresource, &buf)
+	req.Header.Add("X-Remote-User", "system:serviceaccount:default:admin")
+	req = mux.SetURLVars(req, map[string]string{
+		apiserver.NamespaceParamKey: "default",
+		icParamKey:                  "test",
+	})
+	w := httptest.NewRecorder()
+	return req, w
+}

--- a/pkg/apiserver/apis/v1/v1.go
+++ b/pkg/apiserver/apis/v1/v1.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tmax-cloud/cicd-operator/internal/utils"
 	"github.com/tmax-cloud/cicd-operator/internal/wrapper"
 	"github.com/tmax-cloud/cicd-operator/pkg/apiserver/apis/v1/approvals"
+	"github.com/tmax-cloud/cicd-operator/pkg/apiserver/apis/v1/integrationconfigs"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,6 +20,7 @@ const (
 
 type handler struct {
 	approvalsHandler apiserver.APIHandler
+	icHandler        apiserver.APIHandler
 }
 
 // NewHandler instantiates a new v1 api handler
@@ -44,6 +46,13 @@ func NewHandler(parent wrapper.RouterWrapper, cli client.Client, logger logr.Log
 	}
 	handler.approvalsHandler = approvalsHandler
 
+	// /v1/namespaces/<namespace>/integrationconfigs
+	icHandler, err := integrationconfigs.NewHandler(namespaceWrapper, cli, logger)
+	if err != nil {
+		return nil, err
+	}
+	handler.icHandler = icHandler
+
 	return handler, nil
 }
 
@@ -60,6 +69,14 @@ func (h *handler) versionHandler(w http.ResponseWriter, _ *http.Request) {
 		},
 		{
 			Name:       fmt.Sprintf("%s/reject", approvals.ApprovalKind),
+			Namespaced: true,
+		},
+		{
+			Name:       fmt.Sprintf("%s/runpre", integrationconfigs.ICKind),
+			Namespaced: true,
+		},
+		{
+			Name:       fmt.Sprintf("%s/runpost", integrationconfigs.ICKind),
 			Namespaced: true,
 		},
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -36,3 +36,8 @@ const (
 
 // CommitStatusState is a commit status type
 type CommitStatusState string
+
+// FakeSha is a fake SHA for a commit
+const (
+	FakeSha = "0000000000000000000000000000000000000000"
+)

--- a/pkg/git/github/github.go
+++ b/pkg/git/github/github.go
@@ -105,6 +105,12 @@ func (c *Client) SetCommitStatus(integrationJob *cicdv1.IntegrationJob, context 
 	} else {
 		sha = integrationJob.Spec.Refs.Pull.Sha
 	}
+
+	// Don't set commit status if its' sha is a fake
+	if sha == git.FakeSha {
+		return nil
+	}
+
 	apiURL := c.IntegrationConfig.Spec.Git.GetAPIUrl() + "/repos/" + integrationJob.Spec.Refs.Repository + "/statuses/" + sha
 
 	commitStatusBody.State = string(state)

--- a/pkg/git/gitlab/gitlab.go
+++ b/pkg/git/gitlab/gitlab.go
@@ -113,6 +113,12 @@ func (c *Client) SetCommitStatus(integrationJob *cicdv1.IntegrationJob, context 
 	} else {
 		sha = integrationJob.Spec.Refs.Pull.Sha
 	}
+
+	// Don't set commit status if its' sha is a fake
+	if sha == git.FakeSha {
+		return nil
+	}
+
 	apiURL := c.IntegrationConfig.Spec.Git.GetAPIUrl() + "/api/v4/projects/" + urlEncodePath + "/statuses/" + sha
 	switch cicdv1.CommitStatusState(state) {
 	case cicdv1.CommitStatusStatePending:

--- a/pkg/pipelinemanager/step_git_checkout.go
+++ b/pkg/pipelinemanager/step_git_checkout.go
@@ -37,7 +37,7 @@ git fetch "$CHECKOUT_URL" "$CHECKOUT_REF"
 git checkout FETCH_HEAD
 if [ "$CI_BASE_REF" != "" ]; then
     git fetch "$CHECKOUT_URL" "$CI_HEAD_REF"
-    git merge --no-ff "$CI_HEAD_SHA"
+    git merge --no-ff FETCH_HEAD
 fi
 git submodule update --init --recursive
 `

--- a/pkg/server/handler_webhook.go
+++ b/pkg/server/handler_webhook.go
@@ -69,10 +69,7 @@ func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Call plugin functions
-	plugins := getPlugins(wh.EventType)
-	for _, p := range plugins {
-		if err := p.Handle(wh, config); err != nil {
-			log.Error(err, "")
-		}
+	if err := HandleEvent(wh, config); err != nil {
+		log.Error(err, "")
 	}
 }

--- a/pkg/server/plugin.go
+++ b/pkg/server/plugin.go
@@ -12,6 +12,18 @@ type Plugin interface {
 
 var plugins = map[git.EventType][]Plugin{}
 
+// HandleEvent passes webhook event to plugins
+func HandleEvent(wh *git.Webhook, ic *cicdv1.IntegrationConfig) error {
+	var retErr error
+	plugins := getPlugins(wh.EventType)
+	for _, p := range plugins {
+		if err := p.Handle(wh, ic); err != nil {
+			retErr = err
+		}
+	}
+	return retErr
+}
+
 // AddPlugin adds handler for specific events
 func AddPlugin(events []git.EventType, p Plugin) {
 	for _, ev := range events {


### PR DESCRIPTION
- Added api set (/runpre, /runpost) to IntegrationConfig so that users
  can trigger the jobs manually, not via git events.