### PR TITLE
[feat] Implement cicdctl, a CLI tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ test: generate fmt vet manifests
 manager: generate fmt vet
 	go build -o bin/manager main.go
 
+# Build cicdctl binary
+cicdctl:
+	go build -o bin/cicdctl cmd/cicdctl/main.go
+
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
 	go run ./main.go $(RUN_ARGS)
@@ -143,7 +147,7 @@ test-lint:
 
 # Unit test
 test-unit:
-	go test -v ./pkg/...
+	go test -v ./...
 
 save-sha-gen:
 	$(eval GENSHA=$(shell sha512sum api/v1/zz_generated.deepcopy.go))

--- a/cmd/cicdctl/approve/approve.go
+++ b/cmd/cicdctl/approve/approve.go
@@ -1,0 +1,67 @@
+package approve
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/pkg/cli"
+	"log"
+	"strings"
+)
+
+type command struct {
+	ApproveCommand *cobra.Command
+	RejectCommand  *cobra.Command
+
+	Config *cli.Configs
+}
+
+// New is a constructor of the approve sub-command
+func New(c *cli.Configs) cli.Command {
+	cmd := &command{Config: c}
+	cmd.ApproveCommand = approvalCommand(cicdv1.ApprovalAPIApprove, cmd.RunCommand)
+	cmd.RejectCommand = approvalCommand(cicdv1.ApprovalAPIReject, cmd.RunCommand)
+	return cmd
+}
+
+func approvalCommand(kind string, fn func(cmd *cobra.Command, args []string)) *cobra.Command {
+	return &cobra.Command{
+		Use:   kind + " [Approval] [reason]",
+		Short: strings.Title(kind) + "s an Approval",
+		Args:  cobra.ExactArgs(2),
+		Run:   fn,
+	}
+}
+
+func (command *command) AddToCommand(cmd *cobra.Command) {
+	cmd.AddCommand(command.ApproveCommand)
+	cmd.AddCommand(command.RejectCommand)
+}
+
+func (command *command) RunCommand(cmd *cobra.Command, args []string) {
+	approvals := args[0]
+	reason := args[1]
+
+	body, err := json.Marshal(&cicdv1.ApprovalAPIReqBody{
+		Reason: reason,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Run!
+	client, ns, err := cli.GetClient(command.Config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cli.ExecAndHandleError(client.Put().
+		Resource(cicdv1.ApprovalKind).
+		Namespace(ns).
+		Name(approvals).
+		SubResource(cmd.Name()).
+		Body(body))
+
+	fmt.Printf(strings.Title(cmd.Name())+"ed Approval %s/%s\n", ns, approvals)
+}

--- a/cmd/cicdctl/main.go
+++ b/cmd/cicdctl/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/tmax-cloud/cicd-operator/cmd/cicdctl/approve"
+	"github.com/tmax-cloud/cicd-operator/cmd/cicdctl/run"
+	"github.com/tmax-cloud/cicd-operator/pkg/cli"
+	"k8s.io/klog"
+)
+
+func main() {
+	cmd := &cobra.Command{
+		Use:   "cicdctl [Command]",
+		Short: "cicdctl runs CI/CD operator-related tasks",
+	}
+
+	configs := &cli.Configs{}
+	configs.AddFlags(cmd.PersistentFlags())
+
+	approve.New(configs).AddToCommand(cmd)
+	run.New(configs).AddToCommand(cmd)
+
+	// Set klog verbosity
+	klog.InitFlags(nil)
+	pflag.CommandLine.AddGoFlag(flag.CommandLine.Lookup("v"))
+
+	_ = cmd.Execute()
+}

--- a/cmd/cicdctl/run/run.go
+++ b/cmd/cicdctl/run/run.go
@@ -1,0 +1,113 @@
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/pkg/cli"
+	"log"
+)
+
+const (
+	subTypePre  = "pre"
+	subTypePost = "post"
+)
+
+type command struct {
+	*cobra.Command
+
+	Config *cli.Configs
+
+	branch     string
+	headBranch string
+	baseBranch string
+}
+
+// New is a constructor of a run sub-command
+func New(c *cli.Configs) cli.Command {
+	cmd := &command{Config: c}
+	cmd.Command = &cobra.Command{
+		Use:   "run",
+		Short: "Triggers jobs of an IntegrationConfig",
+	}
+
+	preCommand := &cobra.Command{
+		Use:   "pre [IntegrationConfig]",
+		Short: "Triggers preSubmit jobs of an IntegrationConfig",
+		Args:  cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			if cmd.branch != "" {
+				log.Fatal("branch option cannot be used for pre")
+			}
+			if cmd.headBranch == "" {
+				log.Fatal("head-branch option should be set for pre")
+			}
+			cmd.RunCommand(args, subTypePost)
+		},
+	}
+	preCommand.Flags().StringVar(&cmd.baseBranch, "base-branch", "", "Base branch for the PullRequest event")
+	preCommand.Flags().StringVar(&cmd.headBranch, "head-branch", "", "Head branch for the PullRequest event")
+	cmd.Command.AddCommand(preCommand)
+
+	postCommand := &cobra.Command{
+		Use:   "post [IntegrationConfig]",
+		Short: "Triggers postSubmit jobs of an IntegrationConfig",
+		Args:  cobra.ExactArgs(1),
+		Run: func(c *cobra.Command, args []string) {
+			if cmd.headBranch != "" || cmd.baseBranch != "" {
+				log.Fatal("head-branch and base-branch options cannot be used for post")
+			}
+			cmd.RunCommand(args, subTypePre)
+		},
+	}
+	postCommand.Flags().StringVar(&cmd.branch, "branch", "", "Branch for the Push event")
+	cmd.Command.AddCommand(postCommand)
+
+	return cmd
+}
+
+func (command *command) AddToCommand(cmd *cobra.Command) {
+	cmd.AddCommand(command.Command)
+}
+
+func (command *command) RunCommand(args []string, subType string) {
+	ic := args[0]
+
+	var subResource string
+	var obj interface{}
+
+	switch subType {
+	case subTypePre:
+		subResource = cicdv1.IntegrationConfigAPIRunPre
+		obj = cicdv1.IntegrationConfigAPIReqRunPreBody{
+			BaseBranch: command.baseBranch,
+			HeadBranch: command.headBranch,
+		}
+	case subTypePost:
+		subResource = cicdv1.IntegrationConfigAPIRunPost
+		obj = cicdv1.IntegrationConfigAPIReqRunPostBody{
+			Branch: command.branch,
+		}
+	}
+
+	body, err := json.Marshal(obj)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Run!
+	client, ns, err := cli.GetClient(command.Config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cli.ExecAndHandleError(client.Post().
+		Resource(cicdv1.IntegrationConfigKind).
+		Namespace(ns).
+		Name(ic).
+		SubResource(subResource).
+		Body(body))
+
+	fmt.Printf("Triggered %s jobs for IntegrationConfig %s/%s\n", subType, ns, ic)
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,6 +43,9 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 
 func TestAPIs(t *testing.T) {
+	if os.Getenv("TEST_SUITE") == "" {
+		t.Skip("Skipping suite test")
+	}
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,

--- a/docs/approval.md
+++ b/docs/approval.md
@@ -6,6 +6,8 @@ This guide lets you know how to use `Approval` feature.
 * [Reusing Approvers list](#reusing-approvers-list)
 * [Send mail before/after approval](#send-mail-beforeafter-approval)
 * [Approving/Rejecting the approval](#approvingrejecting-the-approval)
+  * [Option.1 Using `cicdctl`](#option-1-using-cicdctl)
+  * [Option.2 Using `curl`](#option-2-using-curl)
 
 ## Creating an `Approval` step
 Add following 'approval' job before the job which needs an approval in `IntegrationConfig`
@@ -72,7 +74,19 @@ Enable email feature, following the [installation guide](./installation.md#enabl
    SERVICE_ACCOUNT=<Name of the service account>
    kubectl get secret $(kubectl get serviceaccount $SERVICE_ACCOUNT -o jsonpath='{.secrets[].name}') -o jsonpath='{.data.token}' | base64 -d
    ```
+
 2. Run API call to Kubernetes API server
+   ### Option. 1 Using `cicdctl`
+   ```bash
+   TOKEN=<Token got from 1.>
+   
+   APPROVAL=<Name of the Approval object>
+   NAMESPACE=<Namespace where the Approval exists>
+   
+   cicdctl --token $TOKEN -n $NAMESPACE [approve|reject] $APPROVAL <Reason of the decision>
+   ```
+
+   ### Option. 2 Using `curl`
    ```bash
    KUBERNETES_API_SERVER=<Kubernetes api server host:port>
    TOKEN=<Token got from 1.>

--- a/docs/cicdctl.md
+++ b/docs/cicdctl.md
@@ -1,0 +1,50 @@
+# `cicdctl`
+
+`cicdctl` is a command-line tool for calling extension APIs for CI/CD operator.
+
+## Building `cicdctl` binary
+```bash
+make cicdctl
+```
+
+## Supported commands
+- [Run](#run)
+- [Approve](#approve)
+- [Reject](#reject)
+
+### Run
+`Run` command triggers jobs of an `IntegrationConfig`.
+#### Command
+`cicdctl run [pre|post] [IntegrationConfig Name]`
+#### Options
+|Name|Description|
+|---|---|
+|`head-branch`| Head branch of the git repository|
+|`base-branch`| Base branch of the git repository|
+#### Examples
+```bash
+# Running preSubmit jobs
+cicdctl run pre -n default ic-test --head-branch test --base-branch master
+
+# Running postSubmit jobs
+cicdctl run post -n default ic-test --branch master
+```
+
+### Approve
+`Approve` command approves an `Approval`
+#### Command
+`cicdctl approve [Approval Name] [Reason]`
+#### Examples
+```bash
+cicdctl approve -n default approval-test 'just because'
+```
+
+### Reject
+`Reject` command rejects an `Approval`
+#### Command
+`cicdctl reject [Approval Name] [Reason]`
+#### Examples
+```bash
+cicdctl reject -n default approval-test 'just because'
+```
+

--- a/docs/integration_config.md
+++ b/docs/integration_config.md
@@ -23,6 +23,8 @@ This guide shows how to configure `IntegrationConfig` in detail.
 - [Configuring `workspaces`](#configuring-workspaces)
 - [Configuring `podTemplate`](#configuring-podtemplate)
 - [Triggering jobs](#triggering-jobs)
+  - [Option.1 Using `cicdctl`](#option1-using-cicdctl)
+  - [Option.2 Using `curl`](#option2-using-curl)
 
 ## Configuring `git`
 For example,
@@ -283,7 +285,12 @@ spec:
 ```
 
 ## Triggering jobs
-Although the jobs are triggered via git event, you can manually trigger them by calling http request.
+Although the jobs are triggered via git event, you can manually trigger them by calling API request.
+### Option.1 Using `cicdctl`
+```bash
+cicdctl run -n <Namespace> post <IntegrationConfig Name>
+```
+### Option.2 Using `curl`
 1. Find the user's token.
    If you are using ServiceAccount, you can find your token with following command
    ```bash

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,15 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/operator-framework/operator-lib v0.1.0
+	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/pipeline v0.19.0
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
+	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.18.8
 	k8s.io/kubernetes v1.13.0
 	knative.dev/pkg v0.0.0-20200922164940-4bf40ad82aab

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,7 @@ github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v0.0.0-20161215172503-049f9b42e9a5/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
@@ -1172,6 +1173,7 @@ github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKv
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/tmax-cloud/cicd-operator/internal/utils"
+	"k8s.io/client-go/rest"
+	"os"
+)
+
+const (
+	apiGroup   = "cicdapi.tmax.io"
+	apiVersion = "v1"
+)
+
+// Command is a cobra wrapper for cli
+type Command interface {
+	AddToCommand(command *cobra.Command)
+}
+
+// GetClient loads kube config and returns a kubernetes rest client
+func GetClient(cfg *Configs) (*rest.RESTClient, string, error) {
+	c, ns, err := LoadKubeConfig(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if c.BearerToken != "" {
+		c.CertData = nil
+		c.KeyData = nil
+	}
+
+	client, err := rest.RESTClientFor(c)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return client, ns, err
+}
+
+// ExecAndHandleError executes the request req and handles error
+func ExecAndHandleError(req *rest.Request) {
+	raw, err := req.DoRaw(context.Background())
+	if err != nil {
+		resp := &utils.ErrorResponse{}
+
+		if err2 := json.Unmarshal(raw, resp); err2 != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+
+		fmt.Println(resp.Message)
+		os.Exit(1)
+	}
+}

--- a/pkg/cli/configs.go
+++ b/pkg/cli/configs.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	flagKubeConfig = "kubeconfig"
+)
+
+// Configs is configs struct for accessing k8s api server
+type Configs struct {
+	KubeConfig string
+
+	CAFile   string
+	CertFile string
+	KeyFile  string
+
+	BearerToken  string
+	Username     string
+	Password     string
+	AuthInfoName string
+	Namespace    string
+
+	ClusterName string
+	Context     string
+	APIServer   string
+
+	Insecure bool
+}
+
+// AddFlags adds flags to a command line. Flags are sampled from kubectl's flags
+func (c *Configs) AddFlags(f *pflag.FlagSet) {
+	f.StringVar(&c.KubeConfig, flagKubeConfig, c.KubeConfig, "Path to the kubeconfig file to use for CLI requests.")
+
+	flags := clientcmd.RecommendedConfigOverrideFlags("")
+
+	f.StringVar(&c.ClusterName, flags.CurrentContext.LongName, c.ClusterName, flags.CurrentContext.Description)
+
+	f.StringVar(&c.CAFile, flags.ClusterOverrideFlags.CertificateAuthority.LongName, c.CAFile, flags.ClusterOverrideFlags.CertificateAuthority.Description)
+	f.BoolVar(&c.Insecure, flags.ClusterOverrideFlags.InsecureSkipTLSVerify.LongName, c.Insecure, flags.ClusterOverrideFlags.InsecureSkipTLSVerify.Description)
+	f.StringVarP(&c.APIServer, flags.ClusterOverrideFlags.APIServer.LongName, "s", c.APIServer, flags.ClusterOverrideFlags.APIServer.Description)
+
+	f.StringVar(&c.Username, flags.AuthOverrideFlags.Username.LongName, c.Username, flags.AuthOverrideFlags.Username.Description)
+	f.StringVar(&c.Password, flags.AuthOverrideFlags.Password.LongName, c.Password, flags.AuthOverrideFlags.Password.Description)
+	f.StringVar(&c.BearerToken, flags.AuthOverrideFlags.Token.LongName, c.BearerToken, flags.AuthOverrideFlags.Token.Description)
+	f.StringVar(&c.CertFile, flags.AuthOverrideFlags.ClientCertificate.LongName, c.CertFile, flags.AuthOverrideFlags.ClientCertificate.Description)
+	f.StringVar(&c.KeyFile, flags.AuthOverrideFlags.ClientKey.LongName, c.KeyFile, flags.AuthOverrideFlags.ClientKey.Description)
+
+	f.StringVarP(&c.Namespace, flags.ContextOverrideFlags.Namespace.LongName, flags.ContextOverrideFlags.Namespace.ShortName, c.Namespace, flags.ContextOverrideFlags.Namespace.Description)
+	f.StringVar(&c.ClusterName, flags.ContextOverrideFlags.ClusterName.LongName, c.ClusterName, flags.ContextOverrideFlags.ClusterName.Description)
+	f.StringVar(&c.AuthInfoName, flags.ContextOverrideFlags.AuthInfoName.LongName, c.AuthInfoName, flags.ContextOverrideFlags.AuthInfoName.Description)
+}

--- a/pkg/cli/kubeconfig.go
+++ b/pkg/cli/kubeconfig.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"os"
+	"os/user"
+	"path"
+)
+
+// LoadKubeConfig parses kube config files
+func LoadKubeConfig(cfg *Configs) (*rest.Config, string, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = cfg.KubeConfig
+	if _, ok := os.LookupEnv("HOME"); !ok {
+		u, err := user.Current()
+		if err != nil {
+			return nil, "", fmt.Errorf("could not get current user: %v", err)
+		}
+		loadingRules.Precedence = append(loadingRules.Precedence, path.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
+	}
+
+	// Override
+	override := &clientcmd.ConfigOverrides{
+		AuthInfo: clientcmdapi.AuthInfo{
+			ClientCertificate: cfg.CertFile,
+			ClientKey:         cfg.KeyFile,
+			Token:             cfg.BearerToken,
+			Username:          cfg.Username,
+			Password:          cfg.Password,
+		},
+		CurrentContext: cfg.Context,
+		Context: clientcmdapi.Context{
+			Cluster:   cfg.ClusterName,
+			AuthInfo:  cfg.AuthInfoName,
+			Namespace: cfg.Namespace,
+		},
+		ClusterInfo: clientcmdapi.Cluster{
+			Server:                cfg.APIServer,
+			InsecureSkipTLSVerify: cfg.Insecure,
+			CertificateAuthority:  cfg.CAFile,
+		},
+	}
+
+	rawCfg := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, override, os.Stdin)
+	cCfg, err := rawCfg.ClientConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	ns, _, err := rawCfg.Namespace()
+	if err != nil {
+		return nil, "", err
+	}
+
+	cCfg.APIPath = "/apis"
+	cCfg.GroupVersion = &schema.GroupVersion{
+		Group:   apiGroup,
+		Version: apiVersion,
+	}
+	cCfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	return cCfg, ns, nil
+}


### PR DESCRIPTION
cicdctl makes it easier to call extension apis, such as
approving/rejecting an approval, or triggering jobs of
IntegrationConfigs.

Refer to the docs and help command for the further usage