### PR TITLE
[fix] Change key for synchronizing pull request pools

### DIFF
--- a/pkg/blocker/checks.go
+++ b/pkg/blocker/checks.go
@@ -110,16 +110,32 @@ func checkAuthor(author string, q cicdv1.MergeQuery) (bool, string) {
 func checkLabels(labels []string, q cicdv1.MergeQuery) (bool, string) {
 	isProperLabels := true
 	msg := ""
-	for _, l := range q.Labels {
-		if !containsString(l, labels) {
-			isProperLabels = false
-			msg = fmt.Sprintf("Label [%s] is required.", l)
+
+	if len(q.Labels) > 0 {
+		var missing []string
+		for _, l := range q.Labels {
+			if !containsString(l, labels) {
+				isProperLabels = false
+				missing = append(missing, l)
+			}
+		}
+		if len(missing) > 0 {
+			msg = fmt.Sprintf("Label [%s] is required.", strings.Join(missing, ","))
 		}
 	}
-	for _, l := range q.BlockLabels {
-		if containsString(l, labels) {
-			isProperLabels = false
-			msg = fmt.Sprintf("Label [%s] is blocking the merge.", l)
+	if len(q.BlockLabels) > 0 {
+		var blocking []string
+		for _, l := range q.BlockLabels {
+			if containsString(l, labels) {
+				isProperLabels = false
+				blocking = append(blocking, l)
+			}
+		}
+		if len(blocking) > 0 {
+			if msg != "" {
+				msg += " "
+			}
+			msg += fmt.Sprintf("Label [%s] is blocking the merge.", strings.Join(blocking, ","))
 		}
 	}
 

--- a/pkg/blocker/checks_test.go
+++ b/pkg/blocker/checks_test.go
@@ -308,7 +308,7 @@ func TestCheckLabels(t *testing.T) {
 	result, msg = checkLabels(labels, query)
 
 	assert.Equal(t, false, result, "Result")
-	assert.Equal(t, "Label [hold] is blocking the merge.", msg, "Message")
+	assert.Equal(t, "Label [lgtm,approved] is required. Label [hold] is blocking the merge.", msg, "Message")
 
 	// Test 7
 	labels = []string{


### PR DESCRIPTION
- Use APIURL/repo as a key for synchronizing PR pools, instead of using
  Namespace/Name of an IntegrationConfig
- Enabled to loop sync periodically
- Refactored blocker's common structures
- Fix label check bug