### PR TITLE
[feat] Add base sha for commit status description

### DIFF
--- a/pkg/pipelinemanager/pipelinemanager_test.go
+++ b/pkg/pipelinemanager/pipelinemanager_test.go
@@ -1,0 +1,26 @@
+package pipelinemanager
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	"testing"
+)
+
+func TestAppendBaseShaToDescription(t *testing.T) {
+	desc := "test description"
+	sha := git.FakeSha
+
+	appended := appendBaseShaToDescription(desc, sha)
+	assert.Equal(t, desc, appended[:len(desc)], "Description")
+	assert.Equal(t, statusDescriptionBaseSHAKey+git.FakeSha, appended[len(appended)-len(statusDescriptionBaseSHAKey+git.FakeSha):], "BaseSHA")
+
+	desc = "description which is very longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"
+	msgLen := statusDescriptionMaxLength - len(statusDescriptionBaseSHAKey) - len(git.FakeSha) - len(statusDescriptionEllipse)
+	appended = appendBaseShaToDescription(desc, sha)
+	assert.Equal(t, desc[:msgLen], appended[:len(desc[:msgLen])], "Description")
+	assert.Equal(t, statusDescriptionBaseSHAKey+git.FakeSha, appended[len(appended)-len(statusDescriptionBaseSHAKey+git.FakeSha):], "BaseSHA")
+
+	sha = ""
+	appended = appendBaseShaToDescription(desc, sha)
+	assert.Equal(t, desc[:statusDescriptionMaxLength], appended, "Description")
+}


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
close #189 

Base SHA is added to the commit statuses' descriptions (only for pull
requests).
It can be used to check if tests are done against the most recent commit
of the target branch before the pull request being merged.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
