### PR TITLE
[feat] Add status syncer to blocker

### DIFF
--- a/docs/blocker.md
+++ b/docs/blocker.md
@@ -1,11 +1,25 @@
 # [WIP] Blocker
 
 Blocker is a helper module for the merge automation.
-
 It literally blocks PullRequests from automatically merged, by setting a commit status `blocker` to the pull request.
 
-After all the merge conditions are met (e.g., branch, author, and label conditions), it checks if all the commit status are successful based on the recent SHA of the base branch.
+After all the **simple merge conditions** (branch, author, and label conditions) are met, it checks the **full merge conditions** (no merge conflict, commit statuses are successful based on the recent SHA of the base branch).
+If the test is successful, merger merges the PR automatically to the base branch.
+If the test is successful but the test was not performed based on the recent base commit, it triggers the test again.
 
-If the test is successful, it merges automatically to the base branch.
+## Merge Pool
+Merge pool is a pool of pull requests satisfies simple conditions for merge.
+There are two separated list of PRs, `pending` and `success`. `pending` pool contains PRs with merge conflicts or unmet commit-status-conditions.
+PRs in `success` pool are ready to be merged. (i.e., satisfies full merge condition)
 
-If the test is successful but it was not performed based on the recent base commit, it triggers the test again.
+## Pool Syncer
+Pool syncer synchronizes (caches) pull requests and checks simple conditions of the PR to be merged.
+The conditions are `author`, (base)`branch`, `labels`. If all the conditions are satisfied, the PR is added to a merge pool.
+Otherwise, the pr is not included in the merge pool.
+
+## Status Syncer
+Status syncer checks full merge conditions for the PRs in the merge pool.
+Also, status syncer reports `blocker` commit status (e.g., In merge pool, Not mergeable) to every PR, including those who are not in the merge pool.
+
+## Merger
+[WIP]

--- a/pkg/blocker/blocker_test.go
+++ b/pkg/blocker/blocker_test.go
@@ -1,0 +1,81 @@
+package blocker
+
+import (
+	"github.com/bmizerany/assert"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	"testing"
+)
+
+func TestMergePool_Add(t *testing.T) {
+	pool := NewMergePool()
+
+	pool.Add(&PullRequest{
+		PullRequest: git.PullRequest{
+			ID: 23,
+		},
+		BlockerStatus:      git.CommitStatusStatePending,
+		BlockerDescription: defaultBlockerMessage,
+	})
+
+	assert.Equal(t, 1, len(pool[git.CommitStatusStatePending]), "Pending length")
+	assert.Equal(t, 0, len(pool[git.CommitStatusStateSuccess]), "Success length")
+	assert.Equal(t, defaultBlockerMessage, pool[git.CommitStatusStatePending][23].BlockerDescription)
+
+	pool.Add(&PullRequest{
+		PullRequest: git.PullRequest{
+			ID: 25,
+		},
+		BlockerStatus:      git.CommitStatusStateSuccess,
+		BlockerDescription: "test message",
+	})
+
+	assert.Equal(t, 1, len(pool[git.CommitStatusStatePending]), "Pending length")
+	assert.Equal(t, 1, len(pool[git.CommitStatusStateSuccess]), "Success length")
+	assert.Equal(t, "test message", pool[git.CommitStatusStateSuccess][25].BlockerDescription)
+}
+
+func TestMergePool_Search(t *testing.T) {
+	pool := NewMergePool()
+
+	pool[git.CommitStatusStatePending][23] = &PullRequest{
+		PullRequest: git.PullRequest{
+			ID: 23,
+		},
+		BlockerStatus:      git.CommitStatusStatePending,
+		BlockerDescription: defaultBlockerMessage,
+	}
+
+	pool[git.CommitStatusStatePending][25] = &PullRequest{
+		PullRequest: git.PullRequest{
+			ID: 25,
+		},
+		BlockerStatus:      git.CommitStatusStateSuccess,
+		BlockerDescription: "test message",
+	}
+
+	found := pool.Search(23)
+	assert.Equal(t, defaultBlockerMessage, found.BlockerDescription, "Found description")
+
+	found = pool.Search(25)
+	assert.Equal(t, "test message", found.BlockerDescription, "Found description")
+
+	found = pool.Search(27)
+	assert.Equal(t, true, found == nil, "Not found")
+}
+
+func TestMergePool_Delete(t *testing.T) {
+	pool := NewMergePool()
+
+	pool[git.CommitStatusStatePending][23] = &PullRequest{
+		PullRequest: git.PullRequest{
+			ID: 23,
+		},
+		BlockerStatus:      git.CommitStatusStatePending,
+		BlockerDescription: defaultBlockerMessage,
+	}
+	assert.Equal(t, 1, len(pool[git.CommitStatusStatePending]))
+
+	pool.Delete(23)
+
+	assert.Equal(t, 0, len(pool[git.CommitStatusStatePending]))
+}

--- a/pkg/blocker/sync_status.go
+++ b/pkg/blocker/sync_status.go
@@ -1,0 +1,121 @@
+package blocker
+
+import (
+	"context"
+	"fmt"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/internal/utils"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+)
+
+// sync_pool.go includes methods for synchronizing PR's commit status/merge conflicts status
+// Also, it updates commit status for all open PRs (not only those in merge pool) if needed
+
+func (b *blocker) loopSyncMergePoolStatus() {
+	// Call sync pool status method whenever a PR pool sync is done
+	for range b.poolSynced {
+		b.syncMergePoolStatus()
+	}
+}
+
+func (b *blocker) syncMergePoolStatus() {
+	log := b.log.WithName("status")
+	log.Info("Synchronizing merge pool status")
+
+	for _, pool := range b.Pools {
+		log := b.log.WithName("status").WithValues("repo", pool.NamespacedName)
+
+		// Get IC
+		ic := &cicdv1.IntegrationConfig{}
+		if err := b.client.Get(context.Background(), pool.NamespacedName, ic); err != nil {
+			log.Error(err, "")
+			continue
+		}
+		if ic.Spec.MergeConfig == nil {
+			continue
+		}
+
+		gitCli, err := utils.GetGitCli(ic, b.client)
+		if err != nil {
+			log.Error(err, "")
+			continue
+		}
+
+		// Get PRs' status for each repository
+		b.syncOneMergePoolStatus(pool, ic, gitCli)
+
+		// Set PRs' commit status for each repository
+		b.reportCommitStatus(pool, ic, gitCli)
+	}
+}
+
+func (b *blocker) syncOneMergePoolStatus(pool *PRPool, ic *cicdv1.IntegrationConfig, gitCli git.Client) {
+	pool.lock.Lock()
+	defer pool.lock.Unlock()
+
+	log := b.log.WithName("status").WithValues("repo", genPoolKey(ic))
+
+	// Loop merge pool per blocker status (pending, success)
+	for oldStatus := range pool.MergePool {
+		// For each PR
+		for prID, pr := range pool.MergePool[oldStatus] {
+			newStatusB, removeFromMergePool, newDescription, err := checkConditionsFull(ic.Spec.MergeConfig.Query, pr.ID, gitCli)
+			if err != nil {
+				log.Error(err, "")
+				continue
+			}
+
+			var newStatus git.CommitStatusState
+			if newStatusB {
+				newStatus = git.CommitStatusStateSuccess
+				newDescription = "In merge pool."
+			} else {
+				newStatus = git.CommitStatusStatePending
+			}
+
+			// Remove from merge pool if simple test fails
+			if removeFromMergePool {
+				delete(pool.MergePool[oldStatus], prID)
+			}
+
+			// Move PR status in the pool
+			if newStatus != oldStatus {
+				delete(pool.MergePool[oldStatus], prID)
+				pool.MergePool[newStatus][prID] = pr
+			}
+
+			// Update status cache
+			if newStatus != pr.BlockerStatus {
+				pr.BlockerStatus = newStatus
+				pr.blockerCacheDirty = true
+			}
+			if newDescription != pr.BlockerDescription {
+				pr.BlockerDescription = newDescription
+				pr.blockerCacheDirty = true
+			}
+
+			log.Info(fmt.Sprintf("\t[#%d](%.20s) - %s/%s", pr.ID, pr.Title, pr.BlockerStatus, pr.BlockerDescription))
+		}
+	}
+}
+
+func (b *blocker) reportCommitStatus(pool *PRPool, ic *cicdv1.IntegrationConfig, gitCli git.Client) {
+	pool.lock.Lock()
+	defer pool.lock.Unlock()
+
+	log := b.log.WithName("status").WithValues("repo", genPoolKey(ic))
+
+	// Update commit status
+	for _, pr := range pool.PullRequests {
+		// Update commit status
+		if pr.blockerCacheDirty {
+			pr.blockerCacheDirty = false
+			blockerURL := "" // TODO
+			log.Info(fmt.Sprintf("Setting commit status %s:%s:%s to %s's %s", blockerContext, pr.BlockerStatus, pr.BlockerDescription, pool.NamespacedName.String(), pr.Head.Sha))
+			if err := gitCli.SetCommitStatus(pr.Head.Sha, blockerContext, pr.BlockerStatus, pr.BlockerDescription, blockerURL); err != nil {
+				log.Error(err, "")
+				continue
+			}
+		}
+	}
+}

--- a/pkg/blocker/sync_status_test.go
+++ b/pkg/blocker/sync_status_test.go
@@ -1,0 +1,144 @@
+package blocker
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/bmizerany/assert"
+	"github.com/gorilla/mux"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	"github.com/tmax-cloud/cicd-operator/pkg/git/github"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
+)
+
+var testSyncStatusPR = github.PullRequest{
+	Head: struct {
+		Ref string `json:"ref"`
+		Sha string `json:"sha"`
+	}{Ref: "newnew", Sha: git.FakeSha},
+	Base: struct {
+		Ref string `json:"ref"`
+		Sha string `json:"sha"`
+	}{Ref: "master", Sha: git.FakeSha},
+	Mergeable: true,
+}
+var testSyncStatusStatuses []github.CommitStatusResponse
+
+func TestBlocker_syncMergePoolStatus(t *testing.T) {
+	fakeCli, ic, _ := syncStatusTestEnv()
+	blocker := New(fakeCli)
+
+	key := genPoolKey(ic)
+	blocker.Pools[key] = NewPRPool(ic.Namespace, ic.Name)
+
+	pool := blocker.Pools[key]
+	pool.MergePool = NewMergePool()
+
+	pr := &PullRequest{
+		PullRequest: git.PullRequest{
+			ID: 25,
+			Head: struct {
+				Ref string
+				Sha string
+			}{Ref: "newnew", Sha: git.FakeSha},
+			Base: struct {
+				Ref string
+				Sha string
+			}{Ref: "master", Sha: git.FakeSha},
+		},
+		BlockerStatus: git.CommitStatusStatePending,
+	}
+	pool.PullRequests[25] = pr
+	pool.MergePool[git.CommitStatusStatePending][25] = pr
+
+	// Test 1
+	blocker.syncMergePoolStatus()
+	assert.Equal(t, 1, len(pool.PullRequests), "PR length")
+	assert.Equal(t, 0, len(pool.MergePool[git.CommitStatusStatePending]), "Pending length")
+	assert.Equal(t, 0, len(pool.MergePool[git.CommitStatusStateSuccess]), "Success length")
+	assert.Equal(t, "Label [approved,lgtm] is required.", pool.PullRequests[25].BlockerDescription, "Blocker status description")
+
+	// Test 2
+	testSyncStatusPR.Mergeable = false
+	testSyncStatusPR.Labels = []struct {
+		Name string `json:"name"`
+	}{{Name: "lgtm"}, {Name: "approved"}}
+	pool.MergePool[git.CommitStatusStatePending][25] = pr
+	blocker.syncMergePoolStatus()
+	assert.Equal(t, 1, len(pool.PullRequests), "PR length")
+	assert.Equal(t, 1, len(pool.MergePool[git.CommitStatusStatePending]), "Pending length")
+	assert.Equal(t, 0, len(pool.MergePool[git.CommitStatusStateSuccess]), "Success length")
+	assert.Equal(t, "Merge conflicts exist. Checks [test-unit] are not successful.", pool.PullRequests[25].BlockerDescription, "Blocker status description")
+
+	// Test 3
+	testSyncStatusPR.Mergeable = true
+	testSyncStatusStatuses = append(testSyncStatusStatuses, github.CommitStatusResponse{Context: "test-unit", State: "success"})
+	pool.MergePool[git.CommitStatusStatePending][25] = pr
+	blocker.syncMergePoolStatus()
+	assert.Equal(t, 1, len(pool.PullRequests), "PR length")
+	assert.Equal(t, 0, len(pool.MergePool[git.CommitStatusStatePending]), "Pending length")
+	assert.Equal(t, 1, len(pool.MergePool[git.CommitStatusStateSuccess]), "Success length")
+	assert.Equal(t, "In merge pool.", pool.PullRequests[25].BlockerDescription, "Blocker status description")
+}
+
+func syncStatusTestEnv() (client.Client, *cicdv1.IntegrationConfig, string) {
+	if _, exist := os.LookupEnv("CI"); !exist {
+		ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(req.URL.String()))
+	})
+	r.HandleFunc("/repos/{org}/{repo}/pulls/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		b, _ := json.Marshal(testSyncStatusPR)
+		_, _ = w.Write(b)
+	})
+	r.HandleFunc("/repos/{org}/{repos}/commits/{sha}/statuses", func(w http.ResponseWriter, req *http.Request) {
+		b, _ := json.Marshal(testSyncStatusStatuses)
+		_, _ = w.Write(b)
+	})
+	r.HandleFunc("/repos/{org}/{repos}/statuses/{sha}", func(_ http.ResponseWriter, _ *http.Request) {})
+	testSrv := httptest.NewServer(r)
+
+	s := runtime.NewScheme()
+	utilruntime.Must(cicdv1.AddToScheme(s))
+
+	ic := &cicdv1.IntegrationConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: cicdv1.IntegrationConfigSpec{
+			Git: cicdv1.GitConfig{
+				Type:       "github",
+				Repository: "tmax-cloud/cicd-operator",
+				APIUrl:     testSrv.URL,
+				Token:      &cicdv1.GitToken{Value: "dummy"},
+			},
+			MergeConfig: &cicdv1.MergeConfig{
+				Query: cicdv1.MergeQuery{
+					Branches:        []string{"master"},
+					Labels:          []string{"lgtm"},
+					BlockLabels:     []string{"hold"},
+					Checks:          []string{"test-unit"},
+					ApproveRequired: true,
+				},
+			},
+			Jobs: cicdv1.IntegrationConfigJobs{},
+		},
+	}
+
+	return fake.NewFakeClientWithScheme(s, ic), ic, fmt.Sprintf("%s/%s", testSrv.URL, ic.Spec.Git.Repository)
+}


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
Every time pool syncer finishes it's job, status syncer starts a job to
synchronize PRs' status.

It checks if PRs in a merge pool is ready to be merged (i.e., meets all
the conditions including commit statuses and merge conflict).

Also, it reports blocker's status (e.g., in-merge-pool, not-mergeable)
to the PRs. It is done for every PRs including those who are not in the
merge pool.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [x] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
