### PR TITLE
[fix] Set default merge method as 'merge'

### DIFF
--- a/pkg/blocker/merge.go
+++ b/pkg/blocker/merge.go
@@ -157,6 +157,9 @@ func (b *blocker) mergePullRequest(pr *PullRequest, ic *cicdv1.IntegrationConfig
 
 func getMergeMethod(pr *PullRequest, ic *cicdv1.IntegrationConfig) git.MergeMethod {
 	method := ic.Spec.MergeConfig.Method
+	if method == "" {
+		method = git.MergeMethodMerge
+	}
 
 	// Check squash/merge label
 	for _, l := range pr.Labels {


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
- This commit avoids errors when the merge method is not set properly.
- Document (/docs/integration_config.md#method) says default value for
  the method is `merge`.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [ ] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
