### PR TITLE
[fix] Differentiate webhook sender and pull request author

### DIFF
--- a/pkg/blocker/checks.go
+++ b/pkg/blocker/checks.go
@@ -33,7 +33,7 @@ func checkConditionsSimple(q cicdv1.MergeQuery, pr *git.PullRequest) (bool, stri
 	}
 
 	// Check author
-	passAuthorCheck, authorCheckMsg := checkAuthor(pr.Sender.Name, q)
+	passAuthorCheck, authorCheckMsg := checkAuthor(pr.Author.Name, q)
 	if authorCheckMsg != "" {
 		messages = append(messages, authorCheckMsg)
 	}

--- a/pkg/blocker/checks_test.go
+++ b/pkg/blocker/checks_test.go
@@ -27,7 +27,7 @@ func TestCheckConditions(t *testing.T) {
 	tc := map[string]checkConditionTestCase{
 		"success": {
 			PR: &git.PullRequest{
-				Sender:    git.User{Name: "cqbqdd11519"},
+				Author:    git.User{Name: "cqbqdd11519"},
 				Base:      git.Base{Ref: "refs/heads/newnew"},
 				Labels:    []git.IssueLabel{{Name: "lgtm"}},
 				Mergeable: true,
@@ -38,7 +38,7 @@ func TestCheckConditions(t *testing.T) {
 		},
 		"failBranch": {
 			PR: &git.PullRequest{
-				Sender:    git.User{Name: "cqbqdd11519"},
+				Author:    git.User{Name: "cqbqdd11519"},
 				Base:      git.Base{Ref: "refs/heads/newnew"},
 				Labels:    []git.IssueLabel{{Name: "lgtm"}},
 				Mergeable: true,
@@ -51,7 +51,7 @@ func TestCheckConditions(t *testing.T) {
 		},
 		"successBranch": {
 			PR: &git.PullRequest{
-				Sender:    git.User{Name: "cqbqdd11519"},
+				Author:    git.User{Name: "cqbqdd11519"},
 				Base:      git.Base{Ref: "refs/heads/newnew"},
 				Labels:    []git.IssueLabel{{Name: "lgtm"}},
 				Mergeable: true,
@@ -64,7 +64,7 @@ func TestCheckConditions(t *testing.T) {
 		},
 		"failLabel": {
 			PR: &git.PullRequest{
-				Sender:    git.User{Name: "cqbqdd11519"},
+				Author:    git.User{Name: "cqbqdd11519"},
 				Base:      git.Base{Ref: "refs/heads/newnew"},
 				Labels:    []git.IssueLabel{{Name: "lgtm"}},
 				Mergeable: true,
@@ -79,7 +79,7 @@ func TestCheckConditions(t *testing.T) {
 		},
 		"failGlobalBlock": {
 			PR: &git.PullRequest{
-				Sender:    git.User{Name: "cqbqdd11519"},
+				Author:    git.User{Name: "cqbqdd11519"},
 				Base:      git.Base{Ref: "refs/heads/newnew"},
 				Labels:    []git.IssueLabel{{Name: "lgtm"}, {Name: "global/block-label"}},
 				Mergeable: true,

--- a/pkg/blocker/merge.go
+++ b/pkg/blocker/merge.go
@@ -100,7 +100,7 @@ func (b *blocker) retestAndMergeOnePool(pool *PRPool) {
 		}
 
 		// Retest it (create IJ) TODO - batched IJ - not implemented yet
-		ij := dispatcher.GeneratePreSubmit(&pr.PullRequest, &git.Repository{Name: ic.Spec.Git.Repository, URL: pr.URL}, &pr.Sender, ic)
+		ij := dispatcher.GeneratePreSubmit(&pr.PullRequest, &git.Repository{Name: ic.Spec.Git.Repository, URL: pr.URL}, &pr.Author, ic)
 		pool.CurrentBatch.Job = types.NamespacedName{Name: ij.Name, Namespace: ij.Namespace}
 		if err := b.client.Create(context.Background(), ij); err != nil {
 			log.Error(err, "")

--- a/pkg/blocker/sync_pool_test.go
+++ b/pkg/blocker/sync_pool_test.go
@@ -49,7 +49,7 @@ func TestBlocker_syncPRs(t *testing.T) {
 		ID:     newPRID,
 		Title:  "[fix] Fix bugs",
 		State:  "open",
-		Sender: git.User{Name: "test"},
+		Author: git.User{Name: "test"},
 		Base:   git.Base{Ref: "master"},
 		Labels: []git.IssueLabel{
 			{Name: "kind/bug"},
@@ -101,7 +101,7 @@ func syncPoolTestEnv() (client.Client, *cicdv1.IntegrationConfig) {
 		ID:     testPRID,
 		Title:  "[feat] New feature",
 		State:  "open",
-		Sender: git.User{Name: "test"},
+		Author: git.User{Name: "test"},
 		Base:   git.Base{Ref: "master"},
 		Labels: []git.IssueLabel{
 			{Name: "kind/feat"},

--- a/pkg/chatops/plugins/approve/handlers_approve_test.go
+++ b/pkg/chatops/plugins/approve/handlers_approve_test.go
@@ -67,7 +67,8 @@ func TestChatOps_handleApprove(t *testing.T) {
 	newUserName := "new-user"
 	gitfake.Users[newUserName] = &git.User{ID: newUserID, Name: newUserName}
 	gitfake.Repos[testRepo].UserCanWrite[newUserName] = false
-	wh.IssueComment.Sender = *gitfake.Users[newUserName]
+	wh.Sender = *gitfake.Users[newUserName]
+	wh.IssueComment.Author = wh.Sender
 	testJobApprove(t, handler, wh, ic, chatops.Command{Type: "approve"}, func() {
 		repo := gitfake.Repos[testRepo]
 		assert.Equal(t, 1, len(repo.Comments[testPRID]), "Comment length")
@@ -136,16 +137,26 @@ func buildTestWebhookForApprove() *git.Webhook {
 		Repo: git.Repository{
 			Name: testRepo,
 		},
+		Sender: git.User{
+			ID:    testUserID,
+			Name:  testUserName,
+			Email: testUserEmail,
+		},
 		IssueComment: &git.IssueComment{
 			Comment: git.Comment{
 				CreatedAt: &metav1.Time{Time: time.Now()},
+			},
+			Author: git.User{
+				ID:    testUserID,
+				Name:  testUserName,
+				Email: testUserEmail,
 			},
 			Issue: git.Issue{
 				PullRequest: &git.PullRequest{
 					ID:    testPRID,
 					Title: "test-pull-request",
 					State: git.PullRequestStateOpen,
-					Sender: git.User{
+					Author: git.User{
 						ID:    testUserID,
 						Name:  testUserName,
 						Email: testUserEmail,
@@ -159,11 +170,6 @@ func buildTestWebhookForApprove() *git.Webhook {
 						Sha: "sfoj39jfsidjf93jfsiljf20",
 					},
 				},
-			},
-			Sender: git.User{
-				ID:    testUserID,
-				Name:  testUserName,
-				Email: testUserEmail,
 			},
 		},
 	}

--- a/pkg/chatops/plugins/trigger/handlers_trigger_test.go
+++ b/pkg/chatops/plugins/trigger/handlers_trigger_test.go
@@ -156,16 +156,26 @@ func buildTestWebhookForTrigger() *git.Webhook {
 			Name: "tmax-cloud/cicd-operator",
 			URL:  "https://github.com/tmax-cloud/cicd-operator",
 		},
+		Sender: git.User{
+			ID:    testUserID,
+			Name:  testUserName,
+			Email: testUserEmail,
+		},
 		IssueComment: &git.IssueComment{
 			Comment: git.Comment{
 				CreatedAt: &metav1.Time{Time: time.Now()},
+			},
+			Author: git.User{
+				ID:    testUserID,
+				Name:  testUserName,
+				Email: testUserEmail,
 			},
 			Issue: git.Issue{
 				PullRequest: &git.PullRequest{
 					ID:    0,
 					Title: "test-pull-request",
 					State: git.PullRequestStateOpen,
-					Sender: git.User{
+					Author: git.User{
 						ID:    testUserID,
 						Name:  testUserName,
 						Email: testUserEmail,
@@ -179,11 +189,6 @@ func buildTestWebhookForTrigger() *git.Webhook {
 						Sha: "sfoj39jfsidjf93jfsiljf20",
 					},
 				},
-			},
-			Sender: git.User{
-				ID:    testUserID,
-				Name:  testUserName,
-				Email: testUserEmail,
 			},
 		},
 	}

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -30,10 +30,10 @@ func (d Dispatcher) Handle(webhook *git.Webhook, config *cicdv1.IntegrationConfi
 
 	if webhook.EventType == git.EventTypePullRequest && pr != nil {
 		if pr.Action == git.PullRequestActionOpen || pr.Action == git.PullRequestActionSynchronize || pr.Action == git.PullRequestActionReOpen {
-			job = GeneratePreSubmit(pr, &webhook.Repo, &pr.Sender, config)
+			job = GeneratePreSubmit(pr, &webhook.Repo, &webhook.Sender, config)
 		}
 	} else if webhook.EventType == git.EventTypePush && push != nil {
-		job = GeneratePostSubmit(push, &webhook.Repo, &push.Sender, config)
+		job = GeneratePostSubmit(push, &webhook.Repo, &webhook.Sender, config)
 	}
 
 	if job == nil {
@@ -82,7 +82,7 @@ func GeneratePreSubmit(pr *git.PullRequest, repo *git.Repository, sender *git.Us
 					Sha:  pr.Head.Sha,
 					Link: pr.URL,
 					Author: cicdv1.IntegrationJobRefsPullAuthor{
-						Name: pr.Sender.Name,
+						Name: pr.Author.Name,
 					},
 				},
 			},

--- a/pkg/git/fake/fake.go
+++ b/pkg/git/fake/fake.go
@@ -188,7 +188,6 @@ func (c *Client) RegisterComment(_ git.IssueType, issueNo int, body string) erro
 				ID: issueNo,
 			},
 		},
-		Sender: git.User{},
 	})
 	return nil
 }

--- a/pkg/git/git_types.go
+++ b/pkg/git/git_types.go
@@ -50,6 +50,7 @@ const (
 type Webhook struct {
 	EventType EventType
 	Repo      Repository
+	Sender    User
 
 	Push         *Push
 	PullRequest  *PullRequest
@@ -58,9 +59,8 @@ type Webhook struct {
 
 // Push is a common structure for push events
 type Push struct {
-	Sender User
-	Ref    string
-	Sha    string
+	Ref string
+	Sha string
 }
 
 // PullRequest is a common structure for pull request events
@@ -69,7 +69,7 @@ type PullRequest struct {
 	Title     string
 	State     PullRequestState
 	Action    PullRequestAction
-	Sender    User
+	Author    User
 	URL       string
 	Base      Base
 	Head      Head
@@ -81,7 +81,7 @@ type PullRequest struct {
 type IssueComment struct {
 	Comment     Comment
 	Issue       Issue
-	Sender      User
+	Author      User
 	ReviewState PullRequestReviewState
 }
 

--- a/pkg/git/github/github.go
+++ b/pkg/git/github/github.go
@@ -342,7 +342,7 @@ func convertPullRequestToShared(pr *PullRequest) *git.PullRequest {
 		ID:    pr.Number,
 		Title: pr.Title,
 		State: git.PullRequestState(pr.State),
-		Sender: git.User{
+		Author: git.User{
 			ID:   pr.User.ID,
 			Name: pr.User.Name,
 		},

--- a/pkg/git/github/webhook.go
+++ b/pkg/git/github/webhook.go
@@ -41,6 +41,7 @@ type PullRequestReviewWebhook struct {
 		Body        string       `json:"body"`
 		SubmittedAt *metav1.Time `json:"submitted_at"`
 		State       string       `json:"state"`
+		User        User         `json:"user"`
 	} `json:"review"`
 	PullRequest PullRequest `json:"pull_request"`
 	Repo        Repo        `json:"repository"`
@@ -97,6 +98,7 @@ type User struct {
 // Comment is a comment payload
 type Comment struct {
 	Body      string       `json:"body"`
+	User      User         `json:"user"`
 	CreatedAt *metav1.Time `json:"created_at"`
 	UpdatedAt *metav1.Time `json:"updated_at"`
 }

--- a/pkg/git/gitlab/gitlab.go
+++ b/pkg/git/gitlab/gitlab.go
@@ -276,7 +276,7 @@ func (c *Client) ListPullRequests(onlyOpen bool) ([]git.PullRequest, error) {
 			ID:    mr.ID,
 			Title: mr.Title,
 			State: convertState(mr.State),
-			Sender: git.User{
+			Author: git.User{
 				ID:   mr.Author.ID,
 				Name: mr.Author.UserName,
 			},
@@ -314,7 +314,7 @@ func (c *Client) GetPullRequest(id int) (*git.PullRequest, error) {
 		ID:    mr.ID,
 		Title: mr.Title,
 		State: convertState(mr.State),
-		Sender: git.User{
+		Author: git.User{
 			ID:   mr.Author.ID,
 			Name: mr.Author.UserName,
 		},


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
In the case of pull-request edit, such as labelling and unlabelling,
webhook's sender is different from the pull request's author.

To authorize labelling/unlabelling event (#226), we should know the
exact sender (who actually labelled the pull request), not the author of
the pull request.

This commit differentiates webhook sedner and pull request author. In
addition, authors of issue comments are differentiated as well.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
