### PR TITLE
[fix] Authorize setter of 'approved' label

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -196,7 +196,7 @@ func main() {
 	// Add plugins for webhook
 	server.AddPlugin([]git.EventType{git.EventTypePullRequest, git.EventTypePush}, &dispatcher.Dispatcher{Client: mgr.GetClient()})
 	server.AddPlugin([]git.EventType{git.EventTypeIssueComment, git.EventTypePullRequestReview, git.EventTypePullRequestReviewComment}, co)
-	server.AddPlugin([]git.EventType{git.EventTypePullRequestReview}, approveHandler)
+	server.AddPlugin([]git.EventType{git.EventTypePullRequest, git.EventTypePullRequestReview}, approveHandler)
 	go srv.Start()
 
 	// Start API aggregation server

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,6 +16,7 @@ The contents are as follows.
 
 ## Create bot account and token
 1. Create account/token
+> DO NOT make pull requests using the bot account. Race can happen on labelling.
 - For GitHub  
   - Create a new bot account
   - Create an access token for the bot account  

--- a/pkg/git/git_types.go
+++ b/pkg/git/git_types.go
@@ -75,6 +75,9 @@ type PullRequest struct {
 	Head      Head
 	Labels    []IssueLabel
 	Mergeable bool
+
+	// LabelChanged
+	LabelChanged []IssueLabel
 }
 
 // IssueComment is a common structure for issue comment

--- a/pkg/git/github/webhook.go
+++ b/pkg/git/github/webhook.go
@@ -11,6 +11,9 @@ type PullRequestWebhook struct {
 	PullRequest PullRequest `json:"pull_request"`
 
 	Repo Repo `json:"repository"`
+
+	// Changed label
+	Label LabelBody `json:"label"`
 }
 
 // PushWebhook is a github-specific push event webhook body

--- a/pkg/git/gitlab/webhook.go
+++ b/pkg/git/gitlab/webhook.go
@@ -18,11 +18,12 @@ type MergeRequestWebhook struct {
 		OldRev string `json:"oldrev"`
 	} `json:"object_attributes"`
 	Project Project `json:"project"`
-	Labels  []struct {
-		Title string `json:"title"`
-	} `json:"labels"`
+	Labels  []Label `json:"labels"`
 	Changes struct {
-		Labels *struct{} `json:"labels"`
+		Labels *struct {
+			Previous []Label `json:"previous"`
+			Current  []Label `json:"current"`
+		} `json:"labels,omitempty"`
 	} `json:"changes"`
 }
 
@@ -71,6 +72,11 @@ type User struct {
 	ID    int    `json:"id"`
 	Name  string `json:"name"`
 	Email string `json:"email"`
+}
+
+// Label is a label struct of an issue/merge request
+type Label struct {
+	Title string `json:"title"`
 }
 
 // RegistrationWebhookBody is a body for requesting webhook registration for the remote git server


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
close #226
This commit prevents an author of a pull request to approve his/her own
pull request.

FYI) If a bot account makes pull requests, race can happen for
'approved' label. (label -> unlabel -> label -> ...)

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [x] Docs included if needed
- [ ] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
