### PR TITLE
[fix] Invalidate pr pool cache if new commit is added

### DIFF
--- a/pkg/blocker/blocker.go
+++ b/pkg/blocker/blocker.go
@@ -165,10 +165,11 @@ func (m MergePool) Delete(id int) {
 type PullRequest struct {
 	git.PullRequest
 
-	// BlockerStatus and BlockerDescription is for caching the commit status values
+	// BlockerStatus, BlockerDescription, and LatestSHA is for caching the commit status values
 	// Only available statuses are pending and success - no failure/error
 	BlockerStatus      git.CommitStatusState
 	BlockerDescription string
+	LatestSHA          string
 
 	// blockerCacheDirty specifies if the commit status should be updated
 	blockerCacheDirty bool

--- a/pkg/blocker/sync_pool.go
+++ b/pkg/blocker/sync_pool.go
@@ -105,6 +105,7 @@ func (b *blocker) syncOnePool(ic *cicdv1.IntegrationConfig) {
 			pr = &PullRequest{
 				BlockerStatus:      git.CommitStatusStatePending,
 				BlockerDescription: defaultBlockerMessage,
+				LatestSHA:          rawPR.Head.Sha,
 			}
 			pool.PullRequests[rawPR.ID] = pr
 		}
@@ -144,6 +145,12 @@ func (b *blocker) syncOnePool(ic *cicdv1.IntegrationConfig) {
 				pr.blockerCacheDirty = true
 			}
 			pr.BlockerDescription = desc
+
+			// Latest SHA
+			if pr.LatestSHA != rawPR.Head.Sha {
+				pr.blockerCacheDirty = true
+			}
+			pr.LatestSHA = rawPR.Head.Sha
 		}
 
 		log.Info(fmt.Sprintf("\t[#%d](%.20s) - merge candidate: %t (%s)", pr.ID, pr.Title, isCandidate, pr.BlockerDescription))


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
Before this commit, when a new commit is added to the pull request,
commit status of blocker to the pull request is not set until conditions
change, because the cache is treated 'not dirty'.

This commit fixes the issue, by setting the cache is dirty when the SHA
changes for the pull request.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [ ] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
