### PR TITLE
[feat] Support batch test using IntegrationJob

### DIFF
--- a/pkg/git/github/parser.go
+++ b/pkg/git/github/parser.go
@@ -2,9 +2,10 @@ package github
 
 import (
 	"encoding/json"
-	"github.com/tmax-cloud/cicd-operator/pkg/git"
 	"strconv"
 	"strings"
+
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
 )
 
 func (c *Client) parsePullRequestWebhook(jsonString []byte) (*git.Webhook, error) {


### PR DESCRIPTION
close #215 
Previously, only one PR can be tested before block-merge.
Now we can test multiple PRs at once by creating IntegrationJob.

Add the field "Sender" to git.PullRequest which be used to create ij.

# Changes
<!--
Describe the changes of the pull request
-->

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
