### PR TITLE
[fix] Set approval sender name as annotation, not label

### DIFF
--- a/controllers/approval_controller.go
+++ b/controllers/approval_controller.go
@@ -165,9 +165,10 @@ func (r *ApprovalReconciler) createOrUpdateRole(approval *cicdv1.Approval) error
 	notExist := false
 	role := &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleAndBindingName(approval.Name),
-			Namespace: approval.Namespace,
-			Labels:    labelsForRoleAndBinding(approval),
+			Name:        roleAndBindingName(approval.Name),
+			Namespace:   approval.Namespace,
+			Labels:      labelsForRoleAndBinding(approval),
+			Annotations: annotationsForRoleAndBinding(approval),
 		},
 	}
 	if err := r.Client.Get(context.Background(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, role); err != nil {
@@ -210,9 +211,10 @@ func (r *ApprovalReconciler) createOrUpdateRole(approval *cicdv1.Approval) error
 func (r *ApprovalReconciler) createOrUpdateRoleBinding(approval *cicdv1.Approval) error {
 	binding := &rbac.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleAndBindingName(approval.Name),
-			Namespace: approval.Namespace,
-			Labels:    labelsForRoleAndBinding(approval),
+			Name:        roleAndBindingName(approval.Name),
+			Namespace:   approval.Namespace,
+			Labels:      labelsForRoleAndBinding(approval),
+			Annotations: annotationsForRoleAndBinding(approval),
 		},
 	}
 	if err := r.Client.Get(context.Background(), types.NamespacedName{Name: binding.Name, Namespace: binding.Namespace}, binding); err != nil {
@@ -287,6 +289,11 @@ func labelsForRoleAndBinding(approval *cicdv1.Approval) map[string]string {
 		cicdv1.JobLabelPrefix + "integrationJob": approval.Spec.IntegrationJob,
 	}
 
+	return result
+}
+
+func annotationsForRoleAndBinding(approval *cicdv1.Approval) map[string]string {
+	result := map[string]string{}
 	if approval.Spec.Sender != nil {
 		result[cicdv1.JobLabelPrefix+"sender"] = approval.Spec.Sender.Name
 	}


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
IMS#265146 Action#1635274
Approval sender's name can be unicode, which is not supported in labels.
To avoid an error which role/rolebinding is not created, this commit
sets sender's name as annotation, not label.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [ ] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
