### PR TITLE
[feat] Add hold plugin

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -10,5 +10,7 @@
 |`/retest`| Trigger all the jobs for the pull request. Same as `/test`. |
 |`/approve`| Approves a PR. Only those who have write access to the repo can call this command. |
 |`/approve cancel`| Cancels an approval on a PR. Only those who have write access to the repo can call this command. |
+|`/hold`| Hold a pull request. Held pull request is not merged automatically.|
+|`/hold cancel`| Unhold a pull request. The pull request can be merged automatically when meets conditions.|
 
 ## Issues

--- a/docs/plugins/hold.md
+++ b/docs/plugins/hold.md
@@ -1,0 +1,8 @@
+## `Hold` ChatOps-Plugin
+
+Hold chat-ops plugin makes it possible to hold a pull request from being merged by commenting on the pull request.
+Anyone can hold the pull request by commenting `/hold` and anyone can cancel the hold by commenting `/hold cancel`.
+
+Label value can be configured via ConfigMap `blocker-config`'s `mergeBlockLabel`
+> **Default Label**  
+> ci/hold

--- a/internal/configs/blocker.go
+++ b/internal/configs/blocker.go
@@ -13,9 +13,9 @@ const (
 func ApplyBlockerConfigChange(cm *corev1.ConfigMap) error {
 	getVars(cm.Data, map[string]operatorConfig{
 		"mergeSyncPeriod":      {Type: cfgTypeInt, IntVal: &MergeSyncPeriod, IntDefault: 1},                               // Merge automation sync period
-		"mergeBlockLabel":      {Type: cfgTypeString, StringVal: &MergeBlockLabel, StringDefault: "ma/block"},             // Merge automation block label
-		"mergeKindSquashLabel": {Type: cfgTypeString, StringVal: &MergeKindSquashLabel, StringDefault: "ma/merge-squash"}, // Merge kind squash label
-		"mergeKindMergeLabel":  {Type: cfgTypeString, StringVal: &MergeKindMergeLabel, StringDefault: "ma/merge-merge"},   // Merge kind squash label
+		"mergeBlockLabel":      {Type: cfgTypeString, StringVal: &MergeBlockLabel, StringDefault: "ci/hold"},              // Merge automation block label
+		"mergeKindSquashLabel": {Type: cfgTypeString, StringVal: &MergeKindSquashLabel, StringDefault: "ci/merge-squash"}, // Merge kind squash label
+		"mergeKindMergeLabel":  {Type: cfgTypeString, StringVal: &MergeKindMergeLabel, StringDefault: "ci/merge-merge"},   // Merge kind squash label
 	})
 
 	// Init

--- a/internal/configs/blocker_test.go
+++ b/internal/configs/blocker_test.go
@@ -14,9 +14,9 @@ func TestApplyBlockerConfigChange(t *testing.T) {
 			assert.Equal(t, true, err == nil)
 
 			assert.Equal(t, 1, MergeSyncPeriod)
-			assert.Equal(t, "ma/block", MergeBlockLabel)
-			assert.Equal(t, "ma/merge-squash", MergeKindSquashLabel)
-			assert.Equal(t, "ma/merge-merge", MergeKindMergeLabel)
+			assert.Equal(t, "ci/hold", MergeBlockLabel)
+			assert.Equal(t, "ci/merge-squash", MergeKindSquashLabel)
+			assert.Equal(t, "ci/merge-merge", MergeKindMergeLabel)
 		}},
 		"normal": {ConfigMap: &corev1.ConfigMap{
 			Data: map[string]string{

--- a/pkg/chatops/plugins/hold/handlers_hold.go
+++ b/pkg/chatops/plugins/hold/handlers_hold.go
@@ -1,0 +1,88 @@
+package hold
+
+import (
+	"fmt"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/internal/configs"
+	"github.com/tmax-cloud/cicd-operator/internal/utils"
+	"github.com/tmax-cloud/cicd-operator/pkg/chatops"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+)
+
+// CommandTypeHold is a hold command type
+const (
+	CommandTypeHold = "hold"
+)
+
+var log = logf.Log.WithName("hold-plugin")
+
+// Handler is an implementation of a ChatOps Handler
+type Handler struct {
+	Client client.Client
+}
+
+// HandleChatOps handles /hold and /hold cancel comment commands
+func (h *Handler) HandleChatOps(command chatops.Command, webhook *git.Webhook, config *cicdv1.IntegrationConfig) error {
+	issueComment := webhook.IssueComment
+	// Do nothing if it's not pull request's comment or it's closed
+	if issueComment.Issue.PullRequest == nil || issueComment.Issue.PullRequest.State != git.PullRequestStateOpen {
+		return nil
+	}
+
+	// Skip if token is empty
+	if config.Spec.Git.Token == nil {
+		return nil
+	}
+
+	gitCli, err := utils.GetGitCli(config, h.Client)
+	if err != nil {
+		return err
+	}
+
+	// /hold
+	if len(command.Args) == 0 {
+		return h.handleHoldCommand(issueComment, gitCli)
+	}
+
+	// /hold cancel
+	if len(command.Args) == 1 && command.Args[0] == "cancel" {
+		return h.handleHoldCancelCommand(issueComment, gitCli)
+	}
+
+	// Default - malformed comment
+	if err := gitCli.RegisterComment(git.IssueTypePullRequest, issueComment.Issue.PullRequest.ID, generateHelpComment()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// handleHoldCommand handles '/hold' command
+func (h *Handler) handleHoldCommand(issueComment *git.IssueComment, gitCli git.Client) error {
+	log.Info(fmt.Sprintf("%s held %s", issueComment.Author.Name, issueComment.Issue.PullRequest.URL))
+	// Register hold label
+	if err := gitCli.SetLabel(git.IssueTypePullRequest, issueComment.Issue.PullRequest.ID, configs.MergeBlockLabel); err != nil {
+		return err
+	}
+	return nil
+}
+
+// handleHoldCancelCommand handles '/hold cancel' command
+func (h *Handler) handleHoldCancelCommand(issueComment *git.IssueComment, gitCli git.Client) error {
+	log.Info(fmt.Sprintf("%s canceled hold on %s", issueComment.Author.Name, issueComment.Issue.PullRequest.URL))
+	// Delete hold label
+	if err := gitCli.DeleteLabel(git.IssueTypePullRequest, issueComment.Issue.PullRequest.ID, configs.MergeBlockLabel); err != nil && !strings.Contains(err.Error(), "Label does not exist") {
+		return err
+	}
+	return nil
+}
+
+func generateHelpComment() string {
+	return "[HOLD ALERT]\n\nHold comment is malformed\n\n" +
+		"You can hold or cancel hold the pull request by commenting...\n" +
+		"- `/hold`\n" +
+		"- `/hold cancel`\n"
+}

--- a/pkg/chatops/plugins/hold/handlers_hold_test.go
+++ b/pkg/chatops/plugins/hold/handlers_hold_test.go
@@ -1,0 +1,167 @@
+package hold
+
+import (
+	"github.com/stretchr/testify/require"
+	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
+	"github.com/tmax-cloud/cicd-operator/internal/configs"
+	"github.com/tmax-cloud/cicd-operator/pkg/chatops"
+	"github.com/tmax-cloud/cicd-operator/pkg/git"
+	gitfake "github.com/tmax-cloud/cicd-operator/pkg/git/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"os"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
+	"time"
+)
+
+const (
+	testRepo = "test/repo"
+	testPRID = 11
+
+	testNamespace  = "default"
+	testConfigName = "test-ic"
+
+	testUserID    = 32
+	testUserName  = "test-user"
+	testUserEmail = "test@test.com"
+)
+
+type chatOpsHoldTestCase struct {
+	command    chatops.Command
+	preFunc    func(wh *git.Webhook)
+	verifyFunc func(t *testing.T)
+}
+
+func TestHandler_HandleChatOps(t *testing.T) {
+	if _, exist := os.LookupEnv("CI"); !exist {
+		ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	}
+	s := runtime.NewScheme()
+	utilruntime.Must(cicdv1.AddToScheme(s))
+
+	ic := buildTestConfigForHold()
+	fakeCli := fake.NewFakeClientWithScheme(s, ic)
+	handler := &Handler{Client: fakeCli}
+
+	// Set configs value
+	configs.MergeBlockLabel = "ci/hold"
+
+	tc := map[string]chatOpsHoldTestCase{
+		"hold": {
+			command: chatops.Command{Type: "hold", Args: []string{}},
+			preFunc: func(wh *git.Webhook) {},
+			verifyFunc: func(t *testing.T) {
+				require.Len(t, gitfake.Repos[testRepo].PullRequests[testPRID].Labels, 1)
+				require.Equal(t, configs.MergeBlockLabel, gitfake.Repos[testRepo].PullRequests[testPRID].Labels[0].Name)
+			},
+		},
+		"holdCancel": {
+			command: chatops.Command{Type: "hold", Args: []string{"cancel"}},
+			preFunc: func(wh *git.Webhook) {
+				gitfake.Repos[testRepo].PullRequests[testPRID].Labels = append(gitfake.Repos[testRepo].PullRequests[testPRID].Labels, git.IssueLabel{Name: configs.MergeBlockLabel})
+			},
+			verifyFunc: func(t *testing.T) {
+				require.Len(t, gitfake.Repos[testRepo].PullRequests[testPRID].Labels, 0)
+			},
+		},
+		"failMalformed": {
+			command: chatops.Command{Type: "hold", Args: []string{"cancellllll"}},
+			preFunc: func(wh *git.Webhook) {},
+			verifyFunc: func(t *testing.T) {
+				require.Len(t, gitfake.Repos[testRepo].PullRequests[testPRID].Labels, 0)
+				require.Len(t, gitfake.Repos[testRepo].Comments[testPRID], 1)
+				require.Equal(t, "[HOLD ALERT]\n\nHold comment is malformed\n\nYou can hold or cancel hold the pull request by commenting...\n- `/hold`\n- `/hold cancel`\n", gitfake.Repos[testRepo].Comments[testPRID][0].Comment.Body)
+			},
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			// Init fake git
+			initFakeGit()
+
+			// Initialize webhook
+			wh := buildTestWebhookCommentHold()
+			c.preFunc(wh)
+
+			err := handler.HandleChatOps(c.command, wh, ic)
+			require.NoError(t, err)
+			c.verifyFunc(t)
+		})
+	}
+}
+
+func initFakeGit() {
+	gitfake.Users = map[string]*git.User{
+		testUserName: {ID: testUserID, Name: testUserName, Email: testUserEmail},
+	}
+	gitfake.Repos = map[string]*gitfake.Repo{
+		testRepo: {
+			PullRequests: map[int]*git.PullRequest{
+				testPRID: {},
+			},
+			Comments: map[int][]git.IssueComment{
+				testPRID: nil,
+			},
+		},
+	}
+}
+
+func buildTestConfigForHold() *cicdv1.IntegrationConfig {
+	return &cicdv1.IntegrationConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigName,
+			Namespace: testNamespace,
+		},
+		Spec: cicdv1.IntegrationConfigSpec{
+			Git: cicdv1.GitConfig{
+				Type:       cicdv1.GitTypeFake,
+				Repository: testRepo,
+				Token:      &cicdv1.GitToken{Value: "dummy"},
+			},
+		},
+	}
+}
+
+func buildTestWebhookCommentHold() *git.Webhook {
+	return &git.Webhook{
+		EventType: git.EventTypeIssueComment,
+		Repo: git.Repository{
+			Name: testRepo,
+		},
+		IssueComment: &git.IssueComment{
+			Comment: git.Comment{
+				CreatedAt: &metav1.Time{Time: time.Now()},
+			},
+			Author: git.User{
+				ID:    testUserID,
+				Name:  testUserName,
+				Email: testUserEmail,
+			},
+			Issue: git.Issue{
+				PullRequest: &git.PullRequest{
+					ID:    testPRID,
+					Title: "test-pull-request",
+					State: git.PullRequestStateOpen,
+					Author: git.User{
+						ID:    testUserID,
+						Name:  testUserName,
+						Email: testUserEmail,
+					},
+					URL: "https://github.com/tmax-cloud/cicd-operator/pulls/1",
+					Base: git.Base{
+						Ref: "master",
+					},
+					Head: git.Head{
+						Ref: "new-feat",
+						Sha: "sfoj39jfsidjf93jfsiljf20",
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
close #243
This commit implements hold plugin. Anyone can hold a pull request from
being merged by commenting '/hold' and can cancel the hold by commenting
'/hold cancel'.

Also, default hold label is changed to ci/hold

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [x] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
