### PR TITLE
[feat] Enable merge commit template

### DIFF
--- a/api/v1/merge_types.go
+++ b/api/v1/merge_types.go
@@ -25,8 +25,7 @@ type MergeConfig struct {
 	Method git.MergeMethod `json:"method,omitempty"`
 
 	// CommitTemplate is a message template for a merge commit.
-	// Currently NOT supported (only uses default commit messages) - to be implemented.
-	// The commit message is compiled as a go template using git.PullRequest object.
+	// The commit message is compiled as a go template using blocker.PullRequest object.
 	CommitTemplate string `json:"commitTemplate,omitempty"`
 
 	// Query is conditions for a open PR to be merged

--- a/config/crd/cicd.tmax.io_integrationconfigs.yaml
+++ b/config/crd/cicd.tmax.io_integrationconfigs.yaml
@@ -3199,9 +3199,8 @@ spec:
                 properties:
                   commitTemplate:
                     description: CommitTemplate is a message template for a merge
-                      commit. Currently NOT supported (only uses default commit messages)
-                      - to be implemented. The commit message is compiled as a go
-                      template using git.PullRequest object.
+                      commit. The commit message is compiled as a go template using
+                      blocker.PullRequest object.
                     type: string
                   method:
                     description: Method is a merge method

--- a/config/release.yaml
+++ b/config/release.yaml
@@ -4198,9 +4198,8 @@ spec:
                 properties:
                   commitTemplate:
                     description: CommitTemplate is a message template for a merge
-                      commit. Currently NOT supported (only uses default commit messages)
-                      - to be implemented. The commit message is compiled as a go
-                      template using git.PullRequest object.
+                      commit. The commit message is compiled as a go template using
+                      blocker.PullRequest object.
                     type: string
                   method:
                     description: Method is a merge method

--- a/docs/integration_config.md
+++ b/docs/integration_config.md
@@ -299,7 +299,8 @@ Merge automation can be configured using `mergeConfig`.
 > Default: `merge`
 
 ### `commitTemplate`
-`commitTemplate` specifies the title template of the merge commit.
+`commitTemplate` specifies the title template of the merge commit. It should be a form of [golang template](https://pkg.go.dev/text/template).
+The template is compiled using a structure [`blocker.PullRequest`](../pkg/blocker/blocker.go)
 > Optional  
 > Default: `{{ .Title }}({{ .ID }})`
 

--- a/pkg/blocker/blocker.go
+++ b/pkg/blocker/blocker.go
@@ -18,15 +18,16 @@ package blocker
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/go-logr/logr"
 	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
 	"github.com/tmax-cloud/cicd-operator/pkg/git"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -192,4 +193,8 @@ type PullRequest struct {
 
 	// Statuses stores whole commit statuses of the PR
 	Statuses map[string]git.CommitStatus
+
+	// Commits are the list of commits in the PR
+	// Only set right before merging it, only if mergeConfig's commitTemplate is not empty
+	Commits []git.Commit
 }

--- a/pkg/git/gitlab/gitlab.go
+++ b/pkg/git/gitlab/gitlab.go
@@ -343,13 +343,19 @@ func (c *Client) GetPullRequest(id int) (*git.PullRequest, error) {
 }
 
 // MergePullRequest merges a pull request
-func (c *Client) MergePullRequest(id int, sha string, method git.MergeMethod, _ string) error {
+func (c *Client) MergePullRequest(id int, sha string, method git.MergeMethod, msg string) error {
 	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/merge_requests/%d/merge", c.IntegrationConfig.Spec.Git.GetAPIUrl(), url.QueryEscape(c.IntegrationConfig.Spec.Git.Repository), id)
 
 	body := &MergeAcceptRequest{
 		Squash:             method == git.MergeMethodSquash,
 		Sha:                sha,
 		RemoveSourceBranch: false,
+	}
+
+	if method == git.MergeMethodSquash {
+		body.SquashCommitMessage = msg
+	} else {
+		body.MergeCommitMessage = msg
 	}
 
 	_, _, err := c.requestHTTP(http.MethodPut, apiURL, body)


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
close #265

If commit template is specified in the IntegrationConfig's mergeConfig,
the template is compiled using blocker.PullRequest struct.
Before compiling it, commits of the pull request is parsed and set to
the structure's Commit field.
User can use the PR's info and commits for writing the message temaplte.

Also, fake git client's MergePullRequest method is implemented. As a
result, there are some modifications in the test codes.

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [x] Docs included if needed
- [x] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
