### PR TITLE
[fix] Trigger only dispatcher plugin for run api

### DIFF
--- a/pkg/apiserver/apis/v1/integrationconfigs/run.go
+++ b/pkg/apiserver/apis/v1/integrationconfigs/run.go
@@ -20,16 +20,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
 	"github.com/gorilla/mux"
 	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
 	"github.com/tmax-cloud/cicd-operator/internal/apiserver"
 	"github.com/tmax-cloud/cicd-operator/internal/utils"
 	"github.com/tmax-cloud/cicd-operator/pkg/git"
 	"github.com/tmax-cloud/cicd-operator/pkg/server"
-	"io"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
-	"regexp"
 )
 
 const (
@@ -115,7 +116,7 @@ func (h *handler) runHandler(w http.ResponseWriter, req *http.Request, et git.Ev
 	}
 
 	// Trigger Run!
-	if err := server.HandleEvent(wh, ic); err != nil {
+	if err := server.HandleEvent(wh, ic, "dispatcher"); err != nil {
 		log.Info(err.Error())
 		_ = utils.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("req: %s, cannot handle event, err : %s", reqID, err.Error()))
 		return

--- a/pkg/chatops/chatops.go
+++ b/pkg/chatops/chatops.go
@@ -17,10 +17,11 @@
 package chatops
 
 import (
+	"strings"
+
 	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
 	"github.com/tmax-cloud/cicd-operator/pkg/git"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 // chatOps triggers tests/retests via comments
@@ -37,6 +38,11 @@ func New(c client.Client) *chatOps {
 	}
 
 	return co
+}
+
+// Name returns a name of the chatOps plugin
+func (c *chatOps) Name() string {
+	return "chatOps"
 }
 
 // Handle actually handles the webhook payload to create IntegrationJob

--- a/pkg/chatops/plugins/approve/handlers_approve.go
+++ b/pkg/chatops/plugins/approve/handlers_approve.go
@@ -18,13 +18,14 @@ package approve
 
 import (
 	"fmt"
+	"strings"
+
 	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
 	"github.com/tmax-cloud/cicd-operator/internal/utils"
 	"github.com/tmax-cloud/cicd-operator/pkg/chatops"
 	"github.com/tmax-cloud/cicd-operator/pkg/git"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 )
 
 // Command types for approve handler
@@ -41,6 +42,11 @@ type Handler struct {
 }
 
 var log = logf.Log.WithName("approve-plugin")
+
+// Name returns a name of the approval plugin
+func (h *Handler) Name() string {
+	return "approve"
+}
 
 // Handle handles a raw webhook
 func (h *Handler) Handle(wh *git.Webhook, ic *cicdv1.IntegrationConfig) error {

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -35,6 +35,11 @@ type Dispatcher struct {
 	Client client.Client
 }
 
+// Name returns a name of dispatcher plugin
+func (d *Dispatcher) Name() string {
+	return "dispatcher"
+}
+
 // Handle handles pull-request and push events
 func (d Dispatcher) Handle(webhook *git.Webhook, config *cicdv1.IntegrationConfig) error {
 	var job *cicdv1.IntegrationJob

--- a/pkg/plugins/size/size.go
+++ b/pkg/plugins/size/size.go
@@ -18,13 +18,14 @@ package size
 
 import (
 	"fmt"
+	"strings"
+
 	cicdv1 "github.com/tmax-cloud/cicd-operator/api/v1"
 	"github.com/tmax-cloud/cicd-operator/internal/configs"
 	"github.com/tmax-cloud/cicd-operator/internal/utils"
 	"github.com/tmax-cloud/cicd-operator/pkg/git"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 )
 
 const (
@@ -49,6 +50,11 @@ var log = logf.Log.WithName("size-plugin")
 // Size plugin finds out how many lines are changed by the pull request and label the size to the pull request
 type Size struct {
 	Client client.Client
+}
+
+// Name returns a name of size plugin
+func (s *Size) Name() string {
+	return "size"
 }
 
 // Handle handles a pull request event and set size label to the pull request


### PR DESCRIPTION
# Changes
<!--
Describe the changes of the pull request
-->
Before this commit, every plugins were called so that if we call
runPre api, size plugin is called so that it occurs an git api error.

To solve this, we call only dispatcher plugin on api calls

# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [ ] Tests included if needed
- [x] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
