### PR TITLE
fix CRD too long to apply - #332

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ run-cicdctl:
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) crd rbac:roleName=cicd-manager-role webhook paths="./..." output:crd:artifacts:config=config/crd
+	$(CONTROLLER_GEN) crd:maxDescLen=0 rbac:roleName=cicd-manager-role webhook paths="./..." output:crd:artifacts:config=config/crd
 	./hack/release-manifest.sh $(VERSION) $(REGISTRY)
 
 # Run go fmt against code

--- a/config/crd/cicd.tmax.io_approvals.yaml
+++ b/config/crd/cicd.tmax.io_approvals.yaml
@@ -32,48 +32,28 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Approval is the Schema for the approvals API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ApprovalSpec defines the desired state of Approval
             properties:
               integrationJob:
-                description: IntegrationJob is a related IntegrationJob name (maybe
-                  a grand-parent of Approval)
                 type: string
               jobName:
-                description: JobName is a name of actual job in IntegrationJob
                 type: string
               link:
-                description: Link is a description link approvers may refer to
                 type: string
               message:
-                description: Message is a message from requester
                 type: string
               pipelineRun:
-                description: PipelineRun points the actual pipeline run object which
-                  created this Approval
                 type: string
               podName:
-                description: 'PodName represents the name of the pod to be approved
-                  to proceed Deprecated: not used from HyperCloud5, only for the backward
-                  compatibility with HyperCloud4'
                 type: string
               sender:
-                description: Sender is a requester (probably be pull-request author
-                  or pusher)
                 properties:
                   email:
                     type: string
@@ -83,14 +63,9 @@ spec:
                 - name
                 type: object
               skipSendMail:
-                description: SkipSendMail describes whether or not to send mail for
-                  request/result for approvers
                 type: boolean
               users:
-                description: Users are the list of the users who are requested to
-                  approve the Approval
                 items:
-                  description: ApprovalUser is a user
                   properties:
                     email:
                       type: string
@@ -104,70 +79,34 @@ spec:
             - users
             type: object
           status:
-            description: ApprovalStatus defines the observed state of Approval
             properties:
               approver:
-                description: Approver is a user who actually approved
                 type: string
               conditions:
-                description: Conditions of Approval
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -180,14 +119,11 @@ spec:
                   type: object
                 type: array
               decisionTime:
-                description: Decision time of Approval
                 format: date-time
                 type: string
               reason:
-                description: Decision message
                 type: string
               result:
-                description: Decision result of Approval
                 type: string
             required:
             - conditions

--- a/config/crd/cicd.tmax.io_integrationconfigs.yaml
+++ b/config/crd/cicd.tmax.io_integrationconfigs.yaml
@@ -32,65 +32,35 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: IntegrationConfig is the Schema for the integrationconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: IntegrationConfigSpec defines the desired state of IntegrationConfig
             properties:
               git:
-                description: Git config for target repository
                 properties:
                   apiUrl:
-                    description: APIUrl for api server (e.g., https://api.github.com
-                      for github type), for the case where the git repository is self-hosted
-                      (should contain specific protocol otherwise webhook server returns
-                      error) Also, it should *NOT* contain repository path (e.g.,
-                      tmax-cloud/cicd-operator)
                     type: string
                   repository:
-                    description: Repository name of git repository (in <org>/<repo>
-                      form, e.g., tmax-cloud/cicd-operator)
                     pattern: .+/.+
                     type: string
                   token:
-                    description: Token is a token for accessing the remote git server.
-                      It can be empty, if you don't want to register a webhook to
-                      the git server
                     properties:
                       value:
-                        description: Value is un-encrypted plain string of git token,
-                          not recommended
                         type: string
                       valueFrom:
-                        description: ValueFrom refers secret. Recommended
                         properties:
                           secretKeyRef:
-                            description: SecretKeySelector selects a key of a Secret.
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
                                 type: boolean
                             required:
                             - key
@@ -100,7 +70,6 @@ spec:
                         type: object
                     type: object
                   type:
-                    description: Type for git remote server
                     enum:
                     - github
                     - gitlab
@@ -110,35 +79,23 @@ spec:
                 - type
                 type: object
               ijManageSpec:
-                description: IJManageSpec defines variables to manage created integration
-                  jobs
                 properties:
                   timeout:
-                    description: Timeout for pending integration job gc
                     type: string
                 type: object
               jobs:
-                description: Jobs specify the tasks to be executed
                 properties:
                   periodic:
-                    description: Periodic are Periodicjobs can be run periodically
                     items:
-                      description: Periodic runs on a time-basis, unrelated to git
-                        changes.
                       properties:
                         after:
-                          description: After configures which jobs should be executed
-                            before this job runs
                           items:
                             type: string
                           type: array
                         approval:
-                          description: Approval
                           properties:
                             approvers:
-                              description: Approvers is a list of approvers
                               items:
-                                description: ApprovalUser is a user
                                 properties:
                                   email:
                                     type: string
@@ -149,185 +106,92 @@ spec:
                                 type: object
                               type: array
                             approversConfigMap:
-                              description: ApproversConfigMap is a configMap Name
-                                containing approvers list should exist in configMap's
-                                'approvers' key, as comma(,) separated list e.g.,
-                                admin-tmax.co.kr=sunghyun_kim3@tmax.co.kr,test-tmax.co.kr=kyunghoon_min@tmax.co.kr
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             requestMessage:
-                              description: RequestMessage is a message to be sent
-                                to approvers by email
                               type: string
                           required:
                           - requestMessage
                           type: object
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME)
-                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
-                            "$(VAR_NAME)". Escaped references will never be expanded,
-                            regardless of whether the variable exists or not. Cannot
-                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
                         command:
-                          description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
-                            provided. Variable references $(VAR_NAME) are expanded
-                            using the container''s environment. If a variable cannot
-                            be resolved, the reference in the input string will be
-                            unchanged. Double $$ are reduced to a single $, which
-                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                            will produce the string literal "$(VAR_NAME)". Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
                         cron:
-                          description: Cron representation of job trigger time
                           type: string
                         email:
-                          description: Email sends email
                           properties:
                             content:
-                              description: Content of the email
                               type: string
                             isHtml:
-                              description: IsHTML describes if it's html content.
-                                Default is false
                               type: boolean
                             receivers:
-                              description: Receivers is a list of email receivers
                               items:
                                 type: string
                               type: array
                             title:
-                              description: Title of the email
                               type: string
                           required:
                           - content
                           - title
                           type: object
                         env:
-                          description: List of environment variables to set in the
-                            container. Cannot be updated.
                           items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
                                 type: string
                               value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previously defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Defaults to
-                                  "".'
                                 type: string
                               valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
                                 properties:
                                   configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
                                         type: boolean
                                     required:
                                     - key
                                     type: object
                                   fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
-                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
                                     type: object
                                   secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
                                     properties:
                                       key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
                                         type: boolean
                                     required:
                                     - key
@@ -338,112 +202,51 @@ spec:
                             type: object
                           type: array
                         envFrom:
-                          description: List of sources to populate environment variables
-                            in the container. The keys defined within a source must
-                            be a C_IDENTIFIER. All invalid keys will be reported as
-                            an event when the container is starting. When a key exists
-                            in multiple sources, the value associated with the last
-                            source will take precedence. Values defined by an Env
-                            with a duplicate key will take precedence. Cannot be updated.
                           items:
-                            description: EnvFromSource represents the source of a
-                              set of ConfigMaps
                             properties:
                               configMapRef:
-                                description: The ConfigMap to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap must
-                                      be defined
                                     type: boolean
                                 type: object
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
-                                description: The Secret to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret must be
-                                      defined
                                     type: boolean
                                 type: object
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                            This field is optional to allow higher level config management
-                            to default or override container images in workload controllers
-                            like Deployments and StatefulSets.'
                           type: string
                         imagePullPolicy:
-                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                            Defaults to Always if :latest tag is specified, or IfNotPresent
-                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                           type: string
                         lifecycle:
-                          description: Actions that the management system should take
-                            in response to container lifecycle events. Cannot be updated.
                           properties:
                             postStart:
-                              description: 'PostStart is called immediately after
-                                a container is created. If the handler fails, the
-                                container is terminated and restarted according to
-                                its restart policy. Other management of the container
-                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request
-                                    to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request.
-                                        HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom
-                                          header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -451,98 +254,49 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                               type: object
                             preStop:
-                              description: 'PreStop is called immediately before a
-                                container is terminated due to an API request or management
-                                event such as liveness/startup probe failure, preemption,
-                                resource contention, etc. The handler is not called
-                                if the container crashes or exits. The reason for
-                                termination is passed to the handler. The Pod''s termination
-                                grace period countdown begins before the PreStop hooked
-                                is executed. Regardless of the outcome of the handler,
-                                the container will eventually terminate within the
-                                Pod''s termination grace period. Other management
-                                of the container blocks until the hook completes or
-                                until the termination grace period is reached. More
-                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request
-                                    to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request.
-                                        HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom
-                                          header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -550,39 +304,25 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
@@ -590,54 +330,27 @@ spec:
                               type: object
                           type: object
                         livenessProbe:
-                          description: 'Periodic probe of container liveness. Container
-                            will be restarted if the probe fails. Cannot be updated.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -645,132 +358,72 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         name:
-                          description: Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                            Cannot be updated.
                           type: string
                         notification:
-                          description: Notification sends notification when success/fail
                           properties:
                             onFailure:
-                              description: OnFailure notifies when the job is failed
                               properties:
                                 email:
-                                  description: Email sends email
                                   properties:
                                     content:
-                                      description: Content of the email
                                       type: string
                                     isHtml:
-                                      description: IsHTML describes if it's html content.
-                                        Default is false
                                       type: boolean
                                     receivers:
-                                      description: Receivers is a list of email receivers
                                       items:
                                         type: string
                                       type: array
                                     title:
-                                      description: Title of the email
                                       type: string
                                   required:
                                   - content
                                   - title
                                   type: object
                                 slack:
-                                  description: Slack sends slack
                                   properties:
                                     message:
-                                      description: Message is a message sent to the
-                                        webhook. It should be a Markdown format. You
-                                        can use $INTEGRATION_JOB_NAME and $JOB_NAME
-                                        variable for IntegrationJob's name and the
-                                        job's name respectively.
                                       type: string
                                     url:
-                                      description: URL is a webhook url of a slack
-                                        app. Refer to https://api.slack.com/messaging/webhooks
                                       type: string
                                   required:
                                   - message
@@ -778,43 +431,28 @@ spec:
                                   type: object
                               type: object
                             onSuccess:
-                              description: OnSuccess notifies when the job is succeeded
                               properties:
                                 email:
-                                  description: Email sends email
                                   properties:
                                     content:
-                                      description: Content of the email
                                       type: string
                                     isHtml:
-                                      description: IsHTML describes if it's html content.
-                                        Default is false
                                       type: boolean
                                     receivers:
-                                      description: Receivers is a list of email receivers
                                       items:
                                         type: string
                                       type: array
                                     title:
-                                      description: Title of the email
                                       type: string
                                   required:
                                   - content
                                   - title
                                   type: object
                                 slack:
-                                  description: Slack sends slack
                                   properties:
                                     message:
-                                      description: Message is a message sent to the
-                                        webhook. It should be a Markdown format. You
-                                        can use $INTEGRATION_JOB_NAME and $JOB_NAME
-                                        variable for IntegrationJob's name and the
-                                        job's name respectively.
                                       type: string
                                     url:
-                                      description: URL is a webhook url of a slack
-                                        app. Refer to https://api.slack.com/messaging/webhooks
                                       type: string
                                   required:
                                   - message
@@ -823,46 +461,20 @@ spec:
                               type: object
                           type: object
                         ports:
-                          description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
                           items:
-                            description: ContainerPort represents a network port in
-                              a single container.
                             properties:
                               containerPort:
-                                description: Number of port to expose on the pod's
-                                  IP address. This must be a valid port number, 0
-                                  < x < 65536.
                                 format: int32
                                 type: integer
                               hostIP:
-                                description: What host IP to bind the external port
-                                  to.
                                 type: string
                               hostPort:
-                                description: Number of port to expose on the host.
-                                  If specified, this must be a valid port number,
-                                  0 < x < 65536. If HostNetwork is specified, this
-                                  must match ContainerPort. Most containers do not
-                                  need this.
                                 format: int32
                                 type: integer
                               name:
-                                description: If specified, this must be an IANA_SVC_NAME
-                                  and unique within the pod. Each named port in a
-                                  pod must have a unique name. Name for the port that
-                                  can be referred to by services.
                                 type: string
                               protocol:
                                 default: TCP
-                                description: Protocol for port. Must be UDP, TCP,
-                                  or SCTP. Defaults to "TCP".
                                 type: string
                             required:
                             - containerPort
@@ -873,54 +485,27 @@ spec:
                           - protocol
                           x-kubernetes-list-type: map
                         readinessProbe:
-                          description: 'Periodic probe of container service readiness.
-                            Container will be removed from service endpoints if the
-                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -928,89 +513,46 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         resources:
-                          description: 'Compute Resources required by this container.
-                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
                             limits:
                               additionalProperties:
@@ -1019,8 +561,6 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                             requests:
                               additionalProperties:
@@ -1029,276 +569,116 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         results:
-                          description: Results emitted by task, which also can be
-                            used as TektonWhen input value.
                           items:
-                            description: TaskResult used to describe the results of
-                              a task
                             properties:
                               description:
-                                description: Description is a human-readable description
-                                  of the result
                                 type: string
                               name:
-                                description: Name the given name
                                 type: string
                             required:
                             - name
                             type: object
                           type: array
                         script:
-                          description: Script will override command of container
                           type: string
                         securityContext:
-                          description: 'SecurityContext defines the security options
-                            the container should be run with. If set, the fields of
-                            SecurityContext override the equivalent fields of PodSecurityContext.
-                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether
-                                a process can gain more privileges than its parent
-                                process. This bool directly controls if the no_new_privs
-                                flag will be set on the container process. AllowPrivilegeEscalation
-                                is true always when the container is: 1) run as Privileged
-                                2) has CAP_SYS_ADMIN'
                               type: boolean
                             capabilities:
-                              description: The capabilities to add/drop when running
-                                containers. Defaults to the default set of capabilities
-                                granted by the container runtime.
                               properties:
                                 add:
-                                  description: Added capabilities
                                   items:
-                                    description: Capability represent POSIX capabilities
-                                      type
                                     type: string
                                   type: array
                                 drop:
-                                  description: Removed capabilities
                                   items:
-                                    description: Capability represent POSIX capabilities
-                                      type
                                     type: string
                                   type: array
                               type: object
                             privileged:
-                              description: Run container in privileged mode. Processes
-                                in privileged containers are essentially equivalent
-                                to root on the host. Defaults to false.
                               type: boolean
                             procMount:
-                              description: procMount denotes the type of proc mount
-                                to use for the containers. The default is DefaultProcMount
-                                which uses the container runtime defaults for readonly
-                                paths and masked paths. This requires the ProcMountType
-                                feature flag to be enabled.
                               type: string
                             readOnlyRootFilesystem:
-                              description: Whether this container has a read-only
-                                root filesystem. Default is false.
                               type: boolean
                             runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be
-                                set in PodSecurityContext.  If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               format: int64
                               type: integer
                             runAsNonRoot:
-                              description: Indicates that the container must run as
-                                a non-root user. If true, the Kubelet will validate
-                                the image at runtime to ensure that it does not run
-                                as UID 0 (root) and fail to start the container if
-                                it does. If unset or false, no such validation will
-                                be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
                               type: boolean
                             runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata
-                                if unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
                               format: int64
                               type: integer
                             seLinuxOptions:
-                              description: The SELinux context to be applied to the
-                                container. If unspecified, the container runtime will
-                                allocate a random SELinux context for each container.  May
-                                also be set in PodSecurityContext.  If set in both
-                                SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
                               properties:
                                 level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
                                   type: string
                                 role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
                                   type: string
                                 type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
                                   type: string
                                 user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
                                   type: string
                               type: object
                             seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod &
-                                container level, the container options override the
-                                pod options.
                               properties:
                                 localhostProfile:
-                                  description: localhostProfile indicates a profile
-                                    defined in a file on the node should be used.
-                                    The profile must be preconfigured on the node
-                                    to work. Must be a descending path, relative to
-                                    the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
                                   type: string
                                 type:
-                                  description: "type indicates which kind of seccomp
-                                    profile will be applied. Valid options are: \n
-                                    Localhost - a profile defined in a file on the
-                                    node should be used. RuntimeDefault - the container
-                                    runtime default profile should be used. Unconfined
-                                    - no profile should be applied."
                                   type: string
                               required:
                               - type
                               type: object
                             windowsOptions:
-                              description: The Windows specific settings applied to
-                                all containers. If unspecified, the options from the
-                                PodSecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               properties:
                                 gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA
-                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec
-                                    named by the GMSACredentialSpecName field.
                                   type: string
                                 gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name
-                                    of the GMSA credential spec to use.
                                   type: string
                                 hostProcess:
-                                  description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
-                                    then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
-                                  description: The UserName in Windows to run the
-                                    entrypoint of the container process. Defaults
-                                    to the user specified in image metadata if unspecified.
-                                    May also be set in PodSecurityContext. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
                                   type: string
                               type: object
                           type: object
                         skipCheckout:
-                          description: SkipCheckout describes whether or not to checkout
-                            from git before
                           type: boolean
                         slack:
-                          description: Slack sends slack
                           properties:
                             message:
-                              description: Message is a message sent to the webhook.
-                                It should be a Markdown format. You can use $INTEGRATION_JOB_NAME
-                                and $JOB_NAME variable for IntegrationJob's name and
-                                the job's name respectively.
                               type: string
                             url:
-                              description: URL is a webhook url of a slack app. Refer
-                                to https://api.slack.com/messaging/webhooks
                               type: string
                           required:
                           - message
                           - url
                           type: object
                         startupProbe:
-                          description: 'StartupProbe indicates that the Pod has successfully
-                            initialized. If specified, no other probes are executed
-                            until this completes successfully. If this probe fails,
-                            the Pod will be restarted, just as if the livenessProbe
-                            failed. This can be used to provide different probe parameters
-                            at the beginning of a Pod''s lifecycle, when it might
-                            take a long time to load data or warm a cache, than during
-                            steady-state operation. This cannot be updated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1306,113 +686,53 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         stdin:
-                          description: Whether this container should allocate a buffer
-                            for stdin in the container runtime. If this is not set,
-                            reads from stdin in the container will always result in
-                            EOF. Default is false.
                           type: boolean
                         stdinOnce:
-                          description: Whether the container runtime should close
-                            the stdin channel after it has been opened by a single
-                            attach. When stdin is true the stdin stream will remain
-                            open across multiple attach sessions. If stdinOnce is
-                            set to true, stdin is opened on container start, is empty
-                            until the first client attaches to stdin, and then remains
-                            open and accepts data until the client disconnects, at
-                            which time stdin is closed and remains closed until the
-                            container is restarted. If this flag is false, a container
-                            processes that reads from stdin will never receive an
-                            EOF. Default is false
                           type: boolean
                         tektonTask:
-                          description: TektonTask is for referring local Tasks or
-                            the Tasks registered in tekton catalog github repo.
                           properties:
                             params:
-                              description: Params are input params for the task
                               items:
-                                description: ParameterValue defines values of parameter
                                 properties:
                                   arrayVal:
                                     items:
@@ -1427,61 +747,29 @@ spec:
                                 type: object
                               type: array
                             resources:
-                              description: Resources are input/output resources for
-                                the task
                               properties:
                                 inputs:
-                                  description: Inputs holds the inputs resources this
-                                    task was invoked with
                                   items:
-                                    description: TaskResourceBinding points to the
-                                      PipelineResource that will be used for the Task
-                                      input or output called Name.
                                     properties:
                                       name:
-                                        description: Name is the name of the PipelineResource
-                                          in the Pipeline's declaration
                                         type: string
                                       paths:
-                                        description: 'Paths will probably be removed
-                                          in #1284, and then PipelineResourceBinding
-                                          can be used instead. The optional Path field
-                                          corresponds to a path on disk at which the
-                                          Resource can be found (used when providing
-                                          the resource via mounted volume, overriding
-                                          the default logic to fetch the Resource).'
                                         items:
                                           type: string
                                         type: array
                                       resourceRef:
-                                        description: ResourceRef is a reference to
-                                          the instance of the actual PipelineResource
-                                          that should be used
                                         properties:
                                           apiVersion:
-                                            description: API version of the referent
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         type: object
                                       resourceSpec:
-                                        description: ResourceSpec is specification
-                                          of a resource that should be created and
-                                          consumed by the task
                                         properties:
                                           description:
-                                            description: Description is a user-facing
-                                              description of the resource that may
-                                              be used to populate a UI.
                                             type: string
                                           params:
                                             items:
-                                              description: ResourceParam declares
-                                                a string value to use for the parameter
-                                                called Name, and is used in the specific
-                                                context of PipelineResources.
                                               properties:
                                                 name:
                                                   type: string
@@ -1493,12 +781,7 @@ spec:
                                               type: object
                                             type: array
                                           secrets:
-                                            description: Secrets to fetch to populate
-                                              some of resource fields
                                             items:
-                                              description: SecretParam indicates which
-                                                secret can be used to populate a field
-                                                of the resource
                                               properties:
                                                 fieldName:
                                                   type: string
@@ -1521,57 +804,27 @@ spec:
                                     type: object
                                   type: array
                                 outputs:
-                                  description: Outputs holds the inputs resources
-                                    this task was invoked with
                                   items:
-                                    description: TaskResourceBinding points to the
-                                      PipelineResource that will be used for the Task
-                                      input or output called Name.
                                     properties:
                                       name:
-                                        description: Name is the name of the PipelineResource
-                                          in the Pipeline's declaration
                                         type: string
                                       paths:
-                                        description: 'Paths will probably be removed
-                                          in #1284, and then PipelineResourceBinding
-                                          can be used instead. The optional Path field
-                                          corresponds to a path on disk at which the
-                                          Resource can be found (used when providing
-                                          the resource via mounted volume, overriding
-                                          the default logic to fetch the Resource).'
                                         items:
                                           type: string
                                         type: array
                                       resourceRef:
-                                        description: ResourceRef is a reference to
-                                          the instance of the actual PipelineResource
-                                          that should be used
                                         properties:
                                           apiVersion:
-                                            description: API version of the referent
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         type: object
                                       resourceSpec:
-                                        description: ResourceSpec is specification
-                                          of a resource that should be created and
-                                          consumed by the task
                                         properties:
                                           description:
-                                            description: Description is a user-facing
-                                              description of the resource that may
-                                              be used to populate a UI.
                                             type: string
                                           params:
                                             items:
-                                              description: ResourceParam declares
-                                                a string value to use for the parameter
-                                                called Name, and is used in the specific
-                                                context of PipelineResources.
                                               properties:
                                                 name:
                                                   type: string
@@ -1583,12 +836,7 @@ spec:
                                               type: object
                                             type: array
                                           secrets:
-                                            description: Secrets to fetch to populate
-                                              some of resource fields
                                             items:
-                                              description: SecretParam indicates which
-                                                secret can be used to populate a field
-                                                of the resource
                                               properties:
                                                 fieldName:
                                                   type: string
@@ -1612,54 +860,29 @@ spec:
                                   type: array
                               type: object
                             taskRef:
-                              description: TaskRef refers to the existing Task in
-                                local cluster or to the tekton catalog github repo.
                               properties:
                                 catalog:
-                                  description: 'Catalog is a name of the task @ tekton
-                                    catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
                                   type: string
                                 local:
-                                  description: Local refers to local tasks/cluster
-                                    tasks
                                   properties:
                                     apiVersion:
-                                      description: API version of the referent
                                       type: string
                                     bundle:
-                                      description: Bundle url reference to a Tekton
-                                        Bundle.
                                       type: string
                                     kind:
-                                      description: TaskKind indicates the kind of
-                                        the task, namespaced or cluster scoped.
                                       type: string
                                     name:
-                                      description: 'Name of the referent; More info:
-                                        http://kubernetes.io/docs/user-guide/identifiers#names'
                                       type: string
                                   type: object
                               type: object
                             workspaces:
-                              description: Workspaces are workspaces for the task
                               items:
-                                description: WorkspacePipelineTaskBinding describes
-                                  how a workspace passed into the pipeline should
-                                  be mapped to a task's declared workspace.
                                 properties:
                                   name:
-                                    description: Name is the name of the workspace
-                                      as declared by the task
                                     type: string
                                   subPath:
-                                    description: SubPath is optionally a directory
-                                      on the volume which should be used for this
-                                      binding (i.e. the volume will be mounted at
-                                      this sub directory).
                                     type: string
                                   workspace:
-                                    description: Workspace is the name of the workspace
-                                      declared by the pipeline
                                     type: string
                                 required:
                                 - name
@@ -1670,26 +893,13 @@ spec:
                           - taskRef
                           type: object
                         tektonWhen:
-                          description: TektonWhen is for conditional execution. Input
-                            can be parameters or results
                           items:
-                            description: WhenExpression allows a PipelineTask to declare
-                              expressions to be evaluated before the Task is run to
-                              determine whether the Task should be executed or skipped
                             properties:
                               input:
-                                description: Input is the string for guard checking
-                                  which can be a static input or an output from a
-                                  parent Task
                                 type: string
                               operator:
-                                description: Operator that represents an Input's relationship
-                                  to the values
                                 type: string
                               values:
-                                description: Values is an array of strings, which
-                                  is compared against the input, for guard checking
-                                  It must be non-empty
                                 items:
                                   type: string
                                 type: array
@@ -1700,44 +910,17 @@ spec:
                             type: object
                           type: array
                         terminationMessagePath:
-                          description: 'Optional: Path at which the file to which
-                            the container''s termination message will be written is
-                            mounted into the container''s filesystem. Message written
-                            is intended to be brief final status, such as an assertion
-                            failure message. Will be truncated by the node if greater
-                            than 4096 bytes. The total message length across all containers
-                            will be limited to 12kb. Defaults to /dev/termination-log.
-                            Cannot be updated.'
                           type: string
                         terminationMessagePolicy:
-                          description: Indicate how the termination message should
-                            be populated. File will use the contents of terminationMessagePath
-                            to populate the container status message on both success
-                            and failure. FallbackToLogsOnError will use the last chunk
-                            of container log output if the termination message file
-                            is empty and the container exited with an error. The log
-                            output is limited to 2048 bytes or 80 lines, whichever
-                            is smaller. Defaults to File. Cannot be updated.
                           type: string
                         tty:
-                          description: Whether this container should allocate a TTY
-                            for itself, also requires 'stdin' to be true. Default
-                            is false.
                           type: boolean
                         volumeDevices:
-                          description: volumeDevices is the list of block devices
-                            to be used by the container.
                           items:
-                            description: volumeDevice describes a mapping of a raw
-                              block device within a container.
                             properties:
                               devicePath:
-                                description: devicePath is the path inside of the
-                                  container that the device will be mapped to.
                                 type: string
                               name:
-                                description: name must match the name of a persistentVolumeClaim
-                                  in the pod
                                 type: string
                             required:
                             - devicePath
@@ -1745,41 +928,19 @@ spec:
                             type: object
                           type: array
                         volumeMounts:
-                          description: Pod volumes to mount into the container's filesystem.
-                            Cannot be updated.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
                                 type: string
                             required:
                             - mountPath
@@ -1787,7 +948,6 @@ spec:
                             type: object
                           type: array
                         when:
-                          description: When is condition for running the job
                           properties:
                             branch:
                               items:
@@ -1807,34 +967,22 @@ spec:
                               type: array
                           type: object
                         workingDir:
-                          description: Container's working directory. If not specified,
-                            the container runtime's default will be used, which might
-                            be configured in the container image. Cannot be updated.
                           type: string
                       required:
                       - name
                       type: object
                     type: array
                   postSubmit:
-                    description: PostSubmit jobs are for push events (including tag
-                      events)
                     items:
-                      description: Job is a specification of the job to be executed
-                        for specific events Same level of task of tekton
                       properties:
                         after:
-                          description: After configures which jobs should be executed
-                            before this job runs
                           items:
                             type: string
                           type: array
                         approval:
-                          description: Approval
                           properties:
                             approvers:
-                              description: Approvers is a list of approvers
                               items:
-                                description: ApprovalUser is a user
                                 properties:
                                   email:
                                     type: string
@@ -1845,182 +993,90 @@ spec:
                                 type: object
                               type: array
                             approversConfigMap:
-                              description: ApproversConfigMap is a configMap Name
-                                containing approvers list should exist in configMap's
-                                'approvers' key, as comma(,) separated list e.g.,
-                                admin-tmax.co.kr=sunghyun_kim3@tmax.co.kr,test-tmax.co.kr=kyunghoon_min@tmax.co.kr
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             requestMessage:
-                              description: RequestMessage is a message to be sent
-                                to approvers by email
                               type: string
                           required:
                           - requestMessage
                           type: object
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME)
-                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
-                            "$(VAR_NAME)". Escaped references will never be expanded,
-                            regardless of whether the variable exists or not. Cannot
-                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
                         command:
-                          description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
-                            provided. Variable references $(VAR_NAME) are expanded
-                            using the container''s environment. If a variable cannot
-                            be resolved, the reference in the input string will be
-                            unchanged. Double $$ are reduced to a single $, which
-                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                            will produce the string literal "$(VAR_NAME)". Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
                         email:
-                          description: Email sends email
                           properties:
                             content:
-                              description: Content of the email
                               type: string
                             isHtml:
-                              description: IsHTML describes if it's html content.
-                                Default is false
                               type: boolean
                             receivers:
-                              description: Receivers is a list of email receivers
                               items:
                                 type: string
                               type: array
                             title:
-                              description: Title of the email
                               type: string
                           required:
                           - content
                           - title
                           type: object
                         env:
-                          description: List of environment variables to set in the
-                            container. Cannot be updated.
                           items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
                                 type: string
                               value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previously defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Defaults to
-                                  "".'
                                 type: string
                               valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
                                 properties:
                                   configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
                                         type: boolean
                                     required:
                                     - key
                                     type: object
                                   fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
-                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
                                     type: object
                                   secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
                                     properties:
                                       key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
                                         type: boolean
                                     required:
                                     - key
@@ -2031,112 +1087,51 @@ spec:
                             type: object
                           type: array
                         envFrom:
-                          description: List of sources to populate environment variables
-                            in the container. The keys defined within a source must
-                            be a C_IDENTIFIER. All invalid keys will be reported as
-                            an event when the container is starting. When a key exists
-                            in multiple sources, the value associated with the last
-                            source will take precedence. Values defined by an Env
-                            with a duplicate key will take precedence. Cannot be updated.
                           items:
-                            description: EnvFromSource represents the source of a
-                              set of ConfigMaps
                             properties:
                               configMapRef:
-                                description: The ConfigMap to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap must
-                                      be defined
                                     type: boolean
                                 type: object
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
-                                description: The Secret to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret must be
-                                      defined
                                     type: boolean
                                 type: object
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                            This field is optional to allow higher level config management
-                            to default or override container images in workload controllers
-                            like Deployments and StatefulSets.'
                           type: string
                         imagePullPolicy:
-                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                            Defaults to Always if :latest tag is specified, or IfNotPresent
-                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                           type: string
                         lifecycle:
-                          description: Actions that the management system should take
-                            in response to container lifecycle events. Cannot be updated.
                           properties:
                             postStart:
-                              description: 'PostStart is called immediately after
-                                a container is created. If the handler fails, the
-                                container is terminated and restarted according to
-                                its restart policy. Other management of the container
-                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request
-                                    to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request.
-                                        HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom
-                                          header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -2144,98 +1139,49 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                               type: object
                             preStop:
-                              description: 'PreStop is called immediately before a
-                                container is terminated due to an API request or management
-                                event such as liveness/startup probe failure, preemption,
-                                resource contention, etc. The handler is not called
-                                if the container crashes or exits. The reason for
-                                termination is passed to the handler. The Pod''s termination
-                                grace period countdown begins before the PreStop hooked
-                                is executed. Regardless of the outcome of the handler,
-                                the container will eventually terminate within the
-                                Pod''s termination grace period. Other management
-                                of the container blocks until the hook completes or
-                                until the termination grace period is reached. More
-                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request
-                                    to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request.
-                                        HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom
-                                          header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -2243,39 +1189,25 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
@@ -2283,54 +1215,27 @@ spec:
                               type: object
                           type: object
                         livenessProbe:
-                          description: 'Periodic probe of container liveness. Container
-                            will be restarted if the probe fails. Cannot be updated.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -2338,132 +1243,72 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         name:
-                          description: Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                            Cannot be updated.
                           type: string
                         notification:
-                          description: Notification sends notification when success/fail
                           properties:
                             onFailure:
-                              description: OnFailure notifies when the job is failed
                               properties:
                                 email:
-                                  description: Email sends email
                                   properties:
                                     content:
-                                      description: Content of the email
                                       type: string
                                     isHtml:
-                                      description: IsHTML describes if it's html content.
-                                        Default is false
                                       type: boolean
                                     receivers:
-                                      description: Receivers is a list of email receivers
                                       items:
                                         type: string
                                       type: array
                                     title:
-                                      description: Title of the email
                                       type: string
                                   required:
                                   - content
                                   - title
                                   type: object
                                 slack:
-                                  description: Slack sends slack
                                   properties:
                                     message:
-                                      description: Message is a message sent to the
-                                        webhook. It should be a Markdown format. You
-                                        can use $INTEGRATION_JOB_NAME and $JOB_NAME
-                                        variable for IntegrationJob's name and the
-                                        job's name respectively.
                                       type: string
                                     url:
-                                      description: URL is a webhook url of a slack
-                                        app. Refer to https://api.slack.com/messaging/webhooks
                                       type: string
                                   required:
                                   - message
@@ -2471,43 +1316,28 @@ spec:
                                   type: object
                               type: object
                             onSuccess:
-                              description: OnSuccess notifies when the job is succeeded
                               properties:
                                 email:
-                                  description: Email sends email
                                   properties:
                                     content:
-                                      description: Content of the email
                                       type: string
                                     isHtml:
-                                      description: IsHTML describes if it's html content.
-                                        Default is false
                                       type: boolean
                                     receivers:
-                                      description: Receivers is a list of email receivers
                                       items:
                                         type: string
                                       type: array
                                     title:
-                                      description: Title of the email
                                       type: string
                                   required:
                                   - content
                                   - title
                                   type: object
                                 slack:
-                                  description: Slack sends slack
                                   properties:
                                     message:
-                                      description: Message is a message sent to the
-                                        webhook. It should be a Markdown format. You
-                                        can use $INTEGRATION_JOB_NAME and $JOB_NAME
-                                        variable for IntegrationJob's name and the
-                                        job's name respectively.
                                       type: string
                                     url:
-                                      description: URL is a webhook url of a slack
-                                        app. Refer to https://api.slack.com/messaging/webhooks
                                       type: string
                                   required:
                                   - message
@@ -2516,46 +1346,20 @@ spec:
                               type: object
                           type: object
                         ports:
-                          description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
                           items:
-                            description: ContainerPort represents a network port in
-                              a single container.
                             properties:
                               containerPort:
-                                description: Number of port to expose on the pod's
-                                  IP address. This must be a valid port number, 0
-                                  < x < 65536.
                                 format: int32
                                 type: integer
                               hostIP:
-                                description: What host IP to bind the external port
-                                  to.
                                 type: string
                               hostPort:
-                                description: Number of port to expose on the host.
-                                  If specified, this must be a valid port number,
-                                  0 < x < 65536. If HostNetwork is specified, this
-                                  must match ContainerPort. Most containers do not
-                                  need this.
                                 format: int32
                                 type: integer
                               name:
-                                description: If specified, this must be an IANA_SVC_NAME
-                                  and unique within the pod. Each named port in a
-                                  pod must have a unique name. Name for the port that
-                                  can be referred to by services.
                                 type: string
                               protocol:
                                 default: TCP
-                                description: Protocol for port. Must be UDP, TCP,
-                                  or SCTP. Defaults to "TCP".
                                 type: string
                             required:
                             - containerPort
@@ -2566,54 +1370,27 @@ spec:
                           - protocol
                           x-kubernetes-list-type: map
                         readinessProbe:
-                          description: 'Periodic probe of container service readiness.
-                            Container will be removed from service endpoints if the
-                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -2621,89 +1398,46 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         resources:
-                          description: 'Compute Resources required by this container.
-                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
                             limits:
                               additionalProperties:
@@ -2712,8 +1446,6 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                             requests:
                               additionalProperties:
@@ -2722,276 +1454,116 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         results:
-                          description: Results emitted by task, which also can be
-                            used as TektonWhen input value.
                           items:
-                            description: TaskResult used to describe the results of
-                              a task
                             properties:
                               description:
-                                description: Description is a human-readable description
-                                  of the result
                                 type: string
                               name:
-                                description: Name the given name
                                 type: string
                             required:
                             - name
                             type: object
                           type: array
                         script:
-                          description: Script will override command of container
                           type: string
                         securityContext:
-                          description: 'SecurityContext defines the security options
-                            the container should be run with. If set, the fields of
-                            SecurityContext override the equivalent fields of PodSecurityContext.
-                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether
-                                a process can gain more privileges than its parent
-                                process. This bool directly controls if the no_new_privs
-                                flag will be set on the container process. AllowPrivilegeEscalation
-                                is true always when the container is: 1) run as Privileged
-                                2) has CAP_SYS_ADMIN'
                               type: boolean
                             capabilities:
-                              description: The capabilities to add/drop when running
-                                containers. Defaults to the default set of capabilities
-                                granted by the container runtime.
                               properties:
                                 add:
-                                  description: Added capabilities
                                   items:
-                                    description: Capability represent POSIX capabilities
-                                      type
                                     type: string
                                   type: array
                                 drop:
-                                  description: Removed capabilities
                                   items:
-                                    description: Capability represent POSIX capabilities
-                                      type
                                     type: string
                                   type: array
                               type: object
                             privileged:
-                              description: Run container in privileged mode. Processes
-                                in privileged containers are essentially equivalent
-                                to root on the host. Defaults to false.
                               type: boolean
                             procMount:
-                              description: procMount denotes the type of proc mount
-                                to use for the containers. The default is DefaultProcMount
-                                which uses the container runtime defaults for readonly
-                                paths and masked paths. This requires the ProcMountType
-                                feature flag to be enabled.
                               type: string
                             readOnlyRootFilesystem:
-                              description: Whether this container has a read-only
-                                root filesystem. Default is false.
                               type: boolean
                             runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be
-                                set in PodSecurityContext.  If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               format: int64
                               type: integer
                             runAsNonRoot:
-                              description: Indicates that the container must run as
-                                a non-root user. If true, the Kubelet will validate
-                                the image at runtime to ensure that it does not run
-                                as UID 0 (root) and fail to start the container if
-                                it does. If unset or false, no such validation will
-                                be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
                               type: boolean
                             runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata
-                                if unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
                               format: int64
                               type: integer
                             seLinuxOptions:
-                              description: The SELinux context to be applied to the
-                                container. If unspecified, the container runtime will
-                                allocate a random SELinux context for each container.  May
-                                also be set in PodSecurityContext.  If set in both
-                                SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
                               properties:
                                 level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
                                   type: string
                                 role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
                                   type: string
                                 type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
                                   type: string
                                 user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
                                   type: string
                               type: object
                             seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod &
-                                container level, the container options override the
-                                pod options.
                               properties:
                                 localhostProfile:
-                                  description: localhostProfile indicates a profile
-                                    defined in a file on the node should be used.
-                                    The profile must be preconfigured on the node
-                                    to work. Must be a descending path, relative to
-                                    the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
                                   type: string
                                 type:
-                                  description: "type indicates which kind of seccomp
-                                    profile will be applied. Valid options are: \n
-                                    Localhost - a profile defined in a file on the
-                                    node should be used. RuntimeDefault - the container
-                                    runtime default profile should be used. Unconfined
-                                    - no profile should be applied."
                                   type: string
                               required:
                               - type
                               type: object
                             windowsOptions:
-                              description: The Windows specific settings applied to
-                                all containers. If unspecified, the options from the
-                                PodSecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               properties:
                                 gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA
-                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec
-                                    named by the GMSACredentialSpecName field.
                                   type: string
                                 gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name
-                                    of the GMSA credential spec to use.
                                   type: string
                                 hostProcess:
-                                  description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
-                                    then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
-                                  description: The UserName in Windows to run the
-                                    entrypoint of the container process. Defaults
-                                    to the user specified in image metadata if unspecified.
-                                    May also be set in PodSecurityContext. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
                                   type: string
                               type: object
                           type: object
                         skipCheckout:
-                          description: SkipCheckout describes whether or not to checkout
-                            from git before
                           type: boolean
                         slack:
-                          description: Slack sends slack
                           properties:
                             message:
-                              description: Message is a message sent to the webhook.
-                                It should be a Markdown format. You can use $INTEGRATION_JOB_NAME
-                                and $JOB_NAME variable for IntegrationJob's name and
-                                the job's name respectively.
                               type: string
                             url:
-                              description: URL is a webhook url of a slack app. Refer
-                                to https://api.slack.com/messaging/webhooks
                               type: string
                           required:
                           - message
                           - url
                           type: object
                         startupProbe:
-                          description: 'StartupProbe indicates that the Pod has successfully
-                            initialized. If specified, no other probes are executed
-                            until this completes successfully. If this probe fails,
-                            the Pod will be restarted, just as if the livenessProbe
-                            failed. This can be used to provide different probe parameters
-                            at the beginning of a Pod''s lifecycle, when it might
-                            take a long time to load data or warm a cache, than during
-                            steady-state operation. This cannot be updated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -2999,113 +1571,53 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         stdin:
-                          description: Whether this container should allocate a buffer
-                            for stdin in the container runtime. If this is not set,
-                            reads from stdin in the container will always result in
-                            EOF. Default is false.
                           type: boolean
                         stdinOnce:
-                          description: Whether the container runtime should close
-                            the stdin channel after it has been opened by a single
-                            attach. When stdin is true the stdin stream will remain
-                            open across multiple attach sessions. If stdinOnce is
-                            set to true, stdin is opened on container start, is empty
-                            until the first client attaches to stdin, and then remains
-                            open and accepts data until the client disconnects, at
-                            which time stdin is closed and remains closed until the
-                            container is restarted. If this flag is false, a container
-                            processes that reads from stdin will never receive an
-                            EOF. Default is false
                           type: boolean
                         tektonTask:
-                          description: TektonTask is for referring local Tasks or
-                            the Tasks registered in tekton catalog github repo.
                           properties:
                             params:
-                              description: Params are input params for the task
                               items:
-                                description: ParameterValue defines values of parameter
                                 properties:
                                   arrayVal:
                                     items:
@@ -3120,61 +1632,29 @@ spec:
                                 type: object
                               type: array
                             resources:
-                              description: Resources are input/output resources for
-                                the task
                               properties:
                                 inputs:
-                                  description: Inputs holds the inputs resources this
-                                    task was invoked with
                                   items:
-                                    description: TaskResourceBinding points to the
-                                      PipelineResource that will be used for the Task
-                                      input or output called Name.
                                     properties:
                                       name:
-                                        description: Name is the name of the PipelineResource
-                                          in the Pipeline's declaration
                                         type: string
                                       paths:
-                                        description: 'Paths will probably be removed
-                                          in #1284, and then PipelineResourceBinding
-                                          can be used instead. The optional Path field
-                                          corresponds to a path on disk at which the
-                                          Resource can be found (used when providing
-                                          the resource via mounted volume, overriding
-                                          the default logic to fetch the Resource).'
                                         items:
                                           type: string
                                         type: array
                                       resourceRef:
-                                        description: ResourceRef is a reference to
-                                          the instance of the actual PipelineResource
-                                          that should be used
                                         properties:
                                           apiVersion:
-                                            description: API version of the referent
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         type: object
                                       resourceSpec:
-                                        description: ResourceSpec is specification
-                                          of a resource that should be created and
-                                          consumed by the task
                                         properties:
                                           description:
-                                            description: Description is a user-facing
-                                              description of the resource that may
-                                              be used to populate a UI.
                                             type: string
                                           params:
                                             items:
-                                              description: ResourceParam declares
-                                                a string value to use for the parameter
-                                                called Name, and is used in the specific
-                                                context of PipelineResources.
                                               properties:
                                                 name:
                                                   type: string
@@ -3186,12 +1666,7 @@ spec:
                                               type: object
                                             type: array
                                           secrets:
-                                            description: Secrets to fetch to populate
-                                              some of resource fields
                                             items:
-                                              description: SecretParam indicates which
-                                                secret can be used to populate a field
-                                                of the resource
                                               properties:
                                                 fieldName:
                                                   type: string
@@ -3214,57 +1689,27 @@ spec:
                                     type: object
                                   type: array
                                 outputs:
-                                  description: Outputs holds the inputs resources
-                                    this task was invoked with
                                   items:
-                                    description: TaskResourceBinding points to the
-                                      PipelineResource that will be used for the Task
-                                      input or output called Name.
                                     properties:
                                       name:
-                                        description: Name is the name of the PipelineResource
-                                          in the Pipeline's declaration
                                         type: string
                                       paths:
-                                        description: 'Paths will probably be removed
-                                          in #1284, and then PipelineResourceBinding
-                                          can be used instead. The optional Path field
-                                          corresponds to a path on disk at which the
-                                          Resource can be found (used when providing
-                                          the resource via mounted volume, overriding
-                                          the default logic to fetch the Resource).'
                                         items:
                                           type: string
                                         type: array
                                       resourceRef:
-                                        description: ResourceRef is a reference to
-                                          the instance of the actual PipelineResource
-                                          that should be used
                                         properties:
                                           apiVersion:
-                                            description: API version of the referent
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         type: object
                                       resourceSpec:
-                                        description: ResourceSpec is specification
-                                          of a resource that should be created and
-                                          consumed by the task
                                         properties:
                                           description:
-                                            description: Description is a user-facing
-                                              description of the resource that may
-                                              be used to populate a UI.
                                             type: string
                                           params:
                                             items:
-                                              description: ResourceParam declares
-                                                a string value to use for the parameter
-                                                called Name, and is used in the specific
-                                                context of PipelineResources.
                                               properties:
                                                 name:
                                                   type: string
@@ -3276,12 +1721,7 @@ spec:
                                               type: object
                                             type: array
                                           secrets:
-                                            description: Secrets to fetch to populate
-                                              some of resource fields
                                             items:
-                                              description: SecretParam indicates which
-                                                secret can be used to populate a field
-                                                of the resource
                                               properties:
                                                 fieldName:
                                                   type: string
@@ -3305,54 +1745,29 @@ spec:
                                   type: array
                               type: object
                             taskRef:
-                              description: TaskRef refers to the existing Task in
-                                local cluster or to the tekton catalog github repo.
                               properties:
                                 catalog:
-                                  description: 'Catalog is a name of the task @ tekton
-                                    catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
                                   type: string
                                 local:
-                                  description: Local refers to local tasks/cluster
-                                    tasks
                                   properties:
                                     apiVersion:
-                                      description: API version of the referent
                                       type: string
                                     bundle:
-                                      description: Bundle url reference to a Tekton
-                                        Bundle.
                                       type: string
                                     kind:
-                                      description: TaskKind indicates the kind of
-                                        the task, namespaced or cluster scoped.
                                       type: string
                                     name:
-                                      description: 'Name of the referent; More info:
-                                        http://kubernetes.io/docs/user-guide/identifiers#names'
                                       type: string
                                   type: object
                               type: object
                             workspaces:
-                              description: Workspaces are workspaces for the task
                               items:
-                                description: WorkspacePipelineTaskBinding describes
-                                  how a workspace passed into the pipeline should
-                                  be mapped to a task's declared workspace.
                                 properties:
                                   name:
-                                    description: Name is the name of the workspace
-                                      as declared by the task
                                     type: string
                                   subPath:
-                                    description: SubPath is optionally a directory
-                                      on the volume which should be used for this
-                                      binding (i.e. the volume will be mounted at
-                                      this sub directory).
                                     type: string
                                   workspace:
-                                    description: Workspace is the name of the workspace
-                                      declared by the pipeline
                                     type: string
                                 required:
                                 - name
@@ -3363,26 +1778,13 @@ spec:
                           - taskRef
                           type: object
                         tektonWhen:
-                          description: TektonWhen is for conditional execution. Input
-                            can be parameters or results
                           items:
-                            description: WhenExpression allows a PipelineTask to declare
-                              expressions to be evaluated before the Task is run to
-                              determine whether the Task should be executed or skipped
                             properties:
                               input:
-                                description: Input is the string for guard checking
-                                  which can be a static input or an output from a
-                                  parent Task
                                 type: string
                               operator:
-                                description: Operator that represents an Input's relationship
-                                  to the values
                                 type: string
                               values:
-                                description: Values is an array of strings, which
-                                  is compared against the input, for guard checking
-                                  It must be non-empty
                                 items:
                                   type: string
                                 type: array
@@ -3393,44 +1795,17 @@ spec:
                             type: object
                           type: array
                         terminationMessagePath:
-                          description: 'Optional: Path at which the file to which
-                            the container''s termination message will be written is
-                            mounted into the container''s filesystem. Message written
-                            is intended to be brief final status, such as an assertion
-                            failure message. Will be truncated by the node if greater
-                            than 4096 bytes. The total message length across all containers
-                            will be limited to 12kb. Defaults to /dev/termination-log.
-                            Cannot be updated.'
                           type: string
                         terminationMessagePolicy:
-                          description: Indicate how the termination message should
-                            be populated. File will use the contents of terminationMessagePath
-                            to populate the container status message on both success
-                            and failure. FallbackToLogsOnError will use the last chunk
-                            of container log output if the termination message file
-                            is empty and the container exited with an error. The log
-                            output is limited to 2048 bytes or 80 lines, whichever
-                            is smaller. Defaults to File. Cannot be updated.
                           type: string
                         tty:
-                          description: Whether this container should allocate a TTY
-                            for itself, also requires 'stdin' to be true. Default
-                            is false.
                           type: boolean
                         volumeDevices:
-                          description: volumeDevices is the list of block devices
-                            to be used by the container.
                           items:
-                            description: volumeDevice describes a mapping of a raw
-                              block device within a container.
                             properties:
                               devicePath:
-                                description: devicePath is the path inside of the
-                                  container that the device will be mapped to.
                                 type: string
                               name:
-                                description: name must match the name of a persistentVolumeClaim
-                                  in the pod
                                 type: string
                             required:
                             - devicePath
@@ -3438,41 +1813,19 @@ spec:
                             type: object
                           type: array
                         volumeMounts:
-                          description: Pod volumes to mount into the container's filesystem.
-                            Cannot be updated.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
                                 type: string
                             required:
                             - mountPath
@@ -3480,7 +1833,6 @@ spec:
                             type: object
                           type: array
                         when:
-                          description: When is condition for running the job
                           properties:
                             branch:
                               items:
@@ -3500,33 +1852,22 @@ spec:
                               type: array
                           type: object
                         workingDir:
-                          description: Container's working directory. If not specified,
-                            the container runtime's default will be used, which might
-                            be configured in the container image. Cannot be updated.
                           type: string
                       required:
                       - name
                       type: object
                     type: array
                   preSubmit:
-                    description: PreSubmit jobs are for pull-request events
                     items:
-                      description: Job is a specification of the job to be executed
-                        for specific events Same level of task of tekton
                       properties:
                         after:
-                          description: After configures which jobs should be executed
-                            before this job runs
                           items:
                             type: string
                           type: array
                         approval:
-                          description: Approval
                           properties:
                             approvers:
-                              description: Approvers is a list of approvers
                               items:
-                                description: ApprovalUser is a user
                                 properties:
                                   email:
                                     type: string
@@ -3537,182 +1878,90 @@ spec:
                                 type: object
                               type: array
                             approversConfigMap:
-                              description: ApproversConfigMap is a configMap Name
-                                containing approvers list should exist in configMap's
-                                'approvers' key, as comma(,) separated list e.g.,
-                                admin-tmax.co.kr=sunghyun_kim3@tmax.co.kr,test-tmax.co.kr=kyunghoon_min@tmax.co.kr
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             requestMessage:
-                              description: RequestMessage is a message to be sent
-                                to approvers by email
                               type: string
                           required:
                           - requestMessage
                           type: object
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME)
-                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
-                            "$(VAR_NAME)". Escaped references will never be expanded,
-                            regardless of whether the variable exists or not. Cannot
-                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
                         command:
-                          description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
-                            provided. Variable references $(VAR_NAME) are expanded
-                            using the container''s environment. If a variable cannot
-                            be resolved, the reference in the input string will be
-                            unchanged. Double $$ are reduced to a single $, which
-                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                            will produce the string literal "$(VAR_NAME)". Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
                         email:
-                          description: Email sends email
                           properties:
                             content:
-                              description: Content of the email
                               type: string
                             isHtml:
-                              description: IsHTML describes if it's html content.
-                                Default is false
                               type: boolean
                             receivers:
-                              description: Receivers is a list of email receivers
                               items:
                                 type: string
                               type: array
                             title:
-                              description: Title of the email
                               type: string
                           required:
                           - content
                           - title
                           type: object
                         env:
-                          description: List of environment variables to set in the
-                            container. Cannot be updated.
                           items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
                                 type: string
                               value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previously defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Defaults to
-                                  "".'
                                 type: string
                               valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
                                 properties:
                                   configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
                                         type: boolean
                                     required:
                                     - key
                                     type: object
                                   fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
-                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
                                     type: object
                                   secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
                                     properties:
                                       key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
                                         type: boolean
                                     required:
                                     - key
@@ -3723,112 +1972,51 @@ spec:
                             type: object
                           type: array
                         envFrom:
-                          description: List of sources to populate environment variables
-                            in the container. The keys defined within a source must
-                            be a C_IDENTIFIER. All invalid keys will be reported as
-                            an event when the container is starting. When a key exists
-                            in multiple sources, the value associated with the last
-                            source will take precedence. Values defined by an Env
-                            with a duplicate key will take precedence. Cannot be updated.
                           items:
-                            description: EnvFromSource represents the source of a
-                              set of ConfigMaps
                             properties:
                               configMapRef:
-                                description: The ConfigMap to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap must
-                                      be defined
                                     type: boolean
                                 type: object
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
-                                description: The Secret to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret must be
-                                      defined
                                     type: boolean
                                 type: object
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                            This field is optional to allow higher level config management
-                            to default or override container images in workload controllers
-                            like Deployments and StatefulSets.'
                           type: string
                         imagePullPolicy:
-                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                            Defaults to Always if :latest tag is specified, or IfNotPresent
-                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                           type: string
                         lifecycle:
-                          description: Actions that the management system should take
-                            in response to container lifecycle events. Cannot be updated.
                           properties:
                             postStart:
-                              description: 'PostStart is called immediately after
-                                a container is created. If the handler fails, the
-                                container is terminated and restarted according to
-                                its restart policy. Other management of the container
-                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request
-                                    to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request.
-                                        HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom
-                                          header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -3836,98 +2024,49 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                               type: object
                             preStop:
-                              description: 'PreStop is called immediately before a
-                                container is terminated due to an API request or management
-                                event such as liveness/startup probe failure, preemption,
-                                resource contention, etc. The handler is not called
-                                if the container crashes or exits. The reason for
-                                termination is passed to the handler. The Pod''s termination
-                                grace period countdown begins before the PreStop hooked
-                                is executed. Regardless of the outcome of the handler,
-                                the container will eventually terminate within the
-                                Pod''s termination grace period. Other management
-                                of the container blocks until the hook completes or
-                                until the termination grace period is reached. More
-                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to
-                                        execute inside the container, the working
-                                        directory for the command  is root ('/') in
-                                        the container's filesystem. The command is
-                                        simply exec'd, it is not run inside a shell,
-                                        so traditional shell instructions ('|', etc)
-                                        won't work. To use a shell, you need to explicitly
-                                        call out to that shell. Exit status of 0 is
-                                        treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 httpGet:
-                                  description: HTTPGet specifies the http request
-                                    to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults
-                                        to the pod IP. You probably want to set "Host"
-                                        in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request.
-                                        HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom
-                                          header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -3935,39 +2074,25 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to
-                                        the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access
-                                        on the container. Number must be in the range
-                                        1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
@@ -3975,54 +2100,27 @@ spec:
                               type: object
                           type: object
                         livenessProbe:
-                          description: 'Periodic probe of container liveness. Container
-                            will be restarted if the probe fails. Cannot be updated.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -4030,132 +2128,72 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         name:
-                          description: Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                            Cannot be updated.
                           type: string
                         notification:
-                          description: Notification sends notification when success/fail
                           properties:
                             onFailure:
-                              description: OnFailure notifies when the job is failed
                               properties:
                                 email:
-                                  description: Email sends email
                                   properties:
                                     content:
-                                      description: Content of the email
                                       type: string
                                     isHtml:
-                                      description: IsHTML describes if it's html content.
-                                        Default is false
                                       type: boolean
                                     receivers:
-                                      description: Receivers is a list of email receivers
                                       items:
                                         type: string
                                       type: array
                                     title:
-                                      description: Title of the email
                                       type: string
                                   required:
                                   - content
                                   - title
                                   type: object
                                 slack:
-                                  description: Slack sends slack
                                   properties:
                                     message:
-                                      description: Message is a message sent to the
-                                        webhook. It should be a Markdown format. You
-                                        can use $INTEGRATION_JOB_NAME and $JOB_NAME
-                                        variable for IntegrationJob's name and the
-                                        job's name respectively.
                                       type: string
                                     url:
-                                      description: URL is a webhook url of a slack
-                                        app. Refer to https://api.slack.com/messaging/webhooks
                                       type: string
                                   required:
                                   - message
@@ -4163,43 +2201,28 @@ spec:
                                   type: object
                               type: object
                             onSuccess:
-                              description: OnSuccess notifies when the job is succeeded
                               properties:
                                 email:
-                                  description: Email sends email
                                   properties:
                                     content:
-                                      description: Content of the email
                                       type: string
                                     isHtml:
-                                      description: IsHTML describes if it's html content.
-                                        Default is false
                                       type: boolean
                                     receivers:
-                                      description: Receivers is a list of email receivers
                                       items:
                                         type: string
                                       type: array
                                     title:
-                                      description: Title of the email
                                       type: string
                                   required:
                                   - content
                                   - title
                                   type: object
                                 slack:
-                                  description: Slack sends slack
                                   properties:
                                     message:
-                                      description: Message is a message sent to the
-                                        webhook. It should be a Markdown format. You
-                                        can use $INTEGRATION_JOB_NAME and $JOB_NAME
-                                        variable for IntegrationJob's name and the
-                                        job's name respectively.
                                       type: string
                                     url:
-                                      description: URL is a webhook url of a slack
-                                        app. Refer to https://api.slack.com/messaging/webhooks
                                       type: string
                                   required:
                                   - message
@@ -4208,46 +2231,20 @@ spec:
                               type: object
                           type: object
                         ports:
-                          description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
                           items:
-                            description: ContainerPort represents a network port in
-                              a single container.
                             properties:
                               containerPort:
-                                description: Number of port to expose on the pod's
-                                  IP address. This must be a valid port number, 0
-                                  < x < 65536.
                                 format: int32
                                 type: integer
                               hostIP:
-                                description: What host IP to bind the external port
-                                  to.
                                 type: string
                               hostPort:
-                                description: Number of port to expose on the host.
-                                  If specified, this must be a valid port number,
-                                  0 < x < 65536. If HostNetwork is specified, this
-                                  must match ContainerPort. Most containers do not
-                                  need this.
                                 format: int32
                                 type: integer
                               name:
-                                description: If specified, this must be an IANA_SVC_NAME
-                                  and unique within the pod. Each named port in a
-                                  pod must have a unique name. Name for the port that
-                                  can be referred to by services.
                                 type: string
                               protocol:
                                 default: TCP
-                                description: Protocol for port. Must be UDP, TCP,
-                                  or SCTP. Defaults to "TCP".
                                 type: string
                             required:
                             - containerPort
@@ -4258,54 +2255,27 @@ spec:
                           - protocol
                           x-kubernetes-list-type: map
                         readinessProbe:
-                          description: 'Periodic probe of container service readiness.
-                            Container will be removed from service endpoints if the
-                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -4313,89 +2283,46 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         resources:
-                          description: 'Compute Resources required by this container.
-                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           properties:
                             limits:
                               additionalProperties:
@@ -4404,8 +2331,6 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                             requests:
                               additionalProperties:
@@ -4414,276 +2339,116 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                         results:
-                          description: Results emitted by task, which also can be
-                            used as TektonWhen input value.
                           items:
-                            description: TaskResult used to describe the results of
-                              a task
                             properties:
                               description:
-                                description: Description is a human-readable description
-                                  of the result
                                 type: string
                               name:
-                                description: Name the given name
                                 type: string
                             required:
                             - name
                             type: object
                           type: array
                         script:
-                          description: Script will override command of container
                           type: string
                         securityContext:
-                          description: 'SecurityContext defines the security options
-                            the container should be run with. If set, the fields of
-                            SecurityContext override the equivalent fields of PodSecurityContext.
-                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
-                              description: 'AllowPrivilegeEscalation controls whether
-                                a process can gain more privileges than its parent
-                                process. This bool directly controls if the no_new_privs
-                                flag will be set on the container process. AllowPrivilegeEscalation
-                                is true always when the container is: 1) run as Privileged
-                                2) has CAP_SYS_ADMIN'
                               type: boolean
                             capabilities:
-                              description: The capabilities to add/drop when running
-                                containers. Defaults to the default set of capabilities
-                                granted by the container runtime.
                               properties:
                                 add:
-                                  description: Added capabilities
                                   items:
-                                    description: Capability represent POSIX capabilities
-                                      type
                                     type: string
                                   type: array
                                 drop:
-                                  description: Removed capabilities
                                   items:
-                                    description: Capability represent POSIX capabilities
-                                      type
                                     type: string
                                   type: array
                               type: object
                             privileged:
-                              description: Run container in privileged mode. Processes
-                                in privileged containers are essentially equivalent
-                                to root on the host. Defaults to false.
                               type: boolean
                             procMount:
-                              description: procMount denotes the type of proc mount
-                                to use for the containers. The default is DefaultProcMount
-                                which uses the container runtime defaults for readonly
-                                paths and masked paths. This requires the ProcMountType
-                                feature flag to be enabled.
                               type: string
                             readOnlyRootFilesystem:
-                              description: Whether this container has a read-only
-                                root filesystem. Default is false.
                               type: boolean
                             runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be
-                                set in PodSecurityContext.  If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               format: int64
                               type: integer
                             runAsNonRoot:
-                              description: Indicates that the container must run as
-                                a non-root user. If true, the Kubelet will validate
-                                the image at runtime to ensure that it does not run
-                                as UID 0 (root) and fail to start the container if
-                                it does. If unset or false, no such validation will
-                                be performed. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
                               type: boolean
                             runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata
-                                if unspecified. May also be set in PodSecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence.
                               format: int64
                               type: integer
                             seLinuxOptions:
-                              description: The SELinux context to be applied to the
-                                container. If unspecified, the container runtime will
-                                allocate a random SELinux context for each container.  May
-                                also be set in PodSecurityContext.  If set in both
-                                SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
                               properties:
                                 level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
                                   type: string
                                 role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
                                   type: string
                                 type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
                                   type: string
                                 user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
                                   type: string
                               type: object
                             seccompProfile:
-                              description: The seccomp options to use by this container.
-                                If seccomp options are provided at both the pod &
-                                container level, the container options override the
-                                pod options.
                               properties:
                                 localhostProfile:
-                                  description: localhostProfile indicates a profile
-                                    defined in a file on the node should be used.
-                                    The profile must be preconfigured on the node
-                                    to work. Must be a descending path, relative to
-                                    the kubelet's configured seccomp profile location.
-                                    Must only be set if type is "Localhost".
                                   type: string
                                 type:
-                                  description: "type indicates which kind of seccomp
-                                    profile will be applied. Valid options are: \n
-                                    Localhost - a profile defined in a file on the
-                                    node should be used. RuntimeDefault - the container
-                                    runtime default profile should be used. Unconfined
-                                    - no profile should be applied."
                                   type: string
                               required:
                               - type
                               type: object
                             windowsOptions:
-                              description: The Windows specific settings applied to
-                                all containers. If unspecified, the options from the
-                                PodSecurityContext will be used. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               properties:
                                 gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA
-                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec
-                                    named by the GMSACredentialSpecName field.
                                   type: string
                                 gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name
-                                    of the GMSA credential spec to use.
                                   type: string
                                 hostProcess:
-                                  description: HostProcess determines if a container
-                                    should be run as a 'Host Process' container. This
-                                    field is alpha-level and will only be honored
-                                    by components that enable the WindowsHostProcessContainers
-                                    feature flag. Setting this field without the feature
-                                    flag will result in errors when validating the
-                                    Pod. All of a Pod's containers must have the same
-                                    effective HostProcess value (it is not allowed
-                                    to have a mix of HostProcess containers and non-HostProcess
-                                    containers).  In addition, if HostProcess is true
-                                    then HostNetwork must also be set to true.
                                   type: boolean
                                 runAsUserName:
-                                  description: The UserName in Windows to run the
-                                    entrypoint of the container process. Defaults
-                                    to the user specified in image metadata if unspecified.
-                                    May also be set in PodSecurityContext. If set
-                                    in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
                                   type: string
                               type: object
                           type: object
                         skipCheckout:
-                          description: SkipCheckout describes whether or not to checkout
-                            from git before
                           type: boolean
                         slack:
-                          description: Slack sends slack
                           properties:
                             message:
-                              description: Message is a message sent to the webhook.
-                                It should be a Markdown format. You can use $INTEGRATION_JOB_NAME
-                                and $JOB_NAME variable for IntegrationJob's name and
-                                the job's name respectively.
                               type: string
                             url:
-                              description: URL is a webhook url of a slack app. Refer
-                                to https://api.slack.com/messaging/webhooks
                               type: string
                           required:
                           - message
                           - url
                           type: object
                         startupProbe:
-                          description: 'StartupProbe indicates that the Pod has successfully
-                            initialized. If specified, no other probes are executed
-                            until this completes successfully. If this probe fails,
-                            the Pod will be restarted, just as if the livenessProbe
-                            failed. This can be used to provide different probe parameters
-                            at the beginning of a Pod''s lifecycle, when it might
-                            take a long time to load data or warm a cache, than during
-                            steady-state operation. This cannot be updated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
                               format: int32
                               type: integer
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -4691,113 +2456,53 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                             periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
                               format: int32
                               type: integer
                             successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully upon probe failure. The grace
-                                period is the duration in seconds after the processes
-                                running in the pod are sent a termination signal and
-                                the time when the processes are forcibly halted with
-                                a kill signal. Set this value longer than the expected
-                                cleanup time for your process. If this value is nil,
-                                the pod's terminationGracePeriodSeconds will be used.
-                                Otherwise, this value overrides the value provided
-                                by the pod spec. Value must be non-negative integer.
-                                The value zero indicates stop immediately via the
-                                kill signal (no opportunity to shut down). This is
-                                a beta field and requires enabling ProbeTerminationGracePeriod
-                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               format: int32
                               type: integer
                           type: object
                         stdin:
-                          description: Whether this container should allocate a buffer
-                            for stdin in the container runtime. If this is not set,
-                            reads from stdin in the container will always result in
-                            EOF. Default is false.
                           type: boolean
                         stdinOnce:
-                          description: Whether the container runtime should close
-                            the stdin channel after it has been opened by a single
-                            attach. When stdin is true the stdin stream will remain
-                            open across multiple attach sessions. If stdinOnce is
-                            set to true, stdin is opened on container start, is empty
-                            until the first client attaches to stdin, and then remains
-                            open and accepts data until the client disconnects, at
-                            which time stdin is closed and remains closed until the
-                            container is restarted. If this flag is false, a container
-                            processes that reads from stdin will never receive an
-                            EOF. Default is false
                           type: boolean
                         tektonTask:
-                          description: TektonTask is for referring local Tasks or
-                            the Tasks registered in tekton catalog github repo.
                           properties:
                             params:
-                              description: Params are input params for the task
                               items:
-                                description: ParameterValue defines values of parameter
                                 properties:
                                   arrayVal:
                                     items:
@@ -4812,61 +2517,29 @@ spec:
                                 type: object
                               type: array
                             resources:
-                              description: Resources are input/output resources for
-                                the task
                               properties:
                                 inputs:
-                                  description: Inputs holds the inputs resources this
-                                    task was invoked with
                                   items:
-                                    description: TaskResourceBinding points to the
-                                      PipelineResource that will be used for the Task
-                                      input or output called Name.
                                     properties:
                                       name:
-                                        description: Name is the name of the PipelineResource
-                                          in the Pipeline's declaration
                                         type: string
                                       paths:
-                                        description: 'Paths will probably be removed
-                                          in #1284, and then PipelineResourceBinding
-                                          can be used instead. The optional Path field
-                                          corresponds to a path on disk at which the
-                                          Resource can be found (used when providing
-                                          the resource via mounted volume, overriding
-                                          the default logic to fetch the Resource).'
                                         items:
                                           type: string
                                         type: array
                                       resourceRef:
-                                        description: ResourceRef is a reference to
-                                          the instance of the actual PipelineResource
-                                          that should be used
                                         properties:
                                           apiVersion:
-                                            description: API version of the referent
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         type: object
                                       resourceSpec:
-                                        description: ResourceSpec is specification
-                                          of a resource that should be created and
-                                          consumed by the task
                                         properties:
                                           description:
-                                            description: Description is a user-facing
-                                              description of the resource that may
-                                              be used to populate a UI.
                                             type: string
                                           params:
                                             items:
-                                              description: ResourceParam declares
-                                                a string value to use for the parameter
-                                                called Name, and is used in the specific
-                                                context of PipelineResources.
                                               properties:
                                                 name:
                                                   type: string
@@ -4878,12 +2551,7 @@ spec:
                                               type: object
                                             type: array
                                           secrets:
-                                            description: Secrets to fetch to populate
-                                              some of resource fields
                                             items:
-                                              description: SecretParam indicates which
-                                                secret can be used to populate a field
-                                                of the resource
                                               properties:
                                                 fieldName:
                                                   type: string
@@ -4906,57 +2574,27 @@ spec:
                                     type: object
                                   type: array
                                 outputs:
-                                  description: Outputs holds the inputs resources
-                                    this task was invoked with
                                   items:
-                                    description: TaskResourceBinding points to the
-                                      PipelineResource that will be used for the Task
-                                      input or output called Name.
                                     properties:
                                       name:
-                                        description: Name is the name of the PipelineResource
-                                          in the Pipeline's declaration
                                         type: string
                                       paths:
-                                        description: 'Paths will probably be removed
-                                          in #1284, and then PipelineResourceBinding
-                                          can be used instead. The optional Path field
-                                          corresponds to a path on disk at which the
-                                          Resource can be found (used when providing
-                                          the resource via mounted volume, overriding
-                                          the default logic to fetch the Resource).'
                                         items:
                                           type: string
                                         type: array
                                       resourceRef:
-                                        description: ResourceRef is a reference to
-                                          the instance of the actual PipelineResource
-                                          that should be used
                                         properties:
                                           apiVersion:
-                                            description: API version of the referent
                                             type: string
                                           name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                             type: string
                                         type: object
                                       resourceSpec:
-                                        description: ResourceSpec is specification
-                                          of a resource that should be created and
-                                          consumed by the task
                                         properties:
                                           description:
-                                            description: Description is a user-facing
-                                              description of the resource that may
-                                              be used to populate a UI.
                                             type: string
                                           params:
                                             items:
-                                              description: ResourceParam declares
-                                                a string value to use for the parameter
-                                                called Name, and is used in the specific
-                                                context of PipelineResources.
                                               properties:
                                                 name:
                                                   type: string
@@ -4968,12 +2606,7 @@ spec:
                                               type: object
                                             type: array
                                           secrets:
-                                            description: Secrets to fetch to populate
-                                              some of resource fields
                                             items:
-                                              description: SecretParam indicates which
-                                                secret can be used to populate a field
-                                                of the resource
                                               properties:
                                                 fieldName:
                                                   type: string
@@ -4997,54 +2630,29 @@ spec:
                                   type: array
                               type: object
                             taskRef:
-                              description: TaskRef refers to the existing Task in
-                                local cluster or to the tekton catalog github repo.
                               properties:
                                 catalog:
-                                  description: 'Catalog is a name of the task @ tekton
-                                    catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
                                   type: string
                                 local:
-                                  description: Local refers to local tasks/cluster
-                                    tasks
                                   properties:
                                     apiVersion:
-                                      description: API version of the referent
                                       type: string
                                     bundle:
-                                      description: Bundle url reference to a Tekton
-                                        Bundle.
                                       type: string
                                     kind:
-                                      description: TaskKind indicates the kind of
-                                        the task, namespaced or cluster scoped.
                                       type: string
                                     name:
-                                      description: 'Name of the referent; More info:
-                                        http://kubernetes.io/docs/user-guide/identifiers#names'
                                       type: string
                                   type: object
                               type: object
                             workspaces:
-                              description: Workspaces are workspaces for the task
                               items:
-                                description: WorkspacePipelineTaskBinding describes
-                                  how a workspace passed into the pipeline should
-                                  be mapped to a task's declared workspace.
                                 properties:
                                   name:
-                                    description: Name is the name of the workspace
-                                      as declared by the task
                                     type: string
                                   subPath:
-                                    description: SubPath is optionally a directory
-                                      on the volume which should be used for this
-                                      binding (i.e. the volume will be mounted at
-                                      this sub directory).
                                     type: string
                                   workspace:
-                                    description: Workspace is the name of the workspace
-                                      declared by the pipeline
                                     type: string
                                 required:
                                 - name
@@ -5055,26 +2663,13 @@ spec:
                           - taskRef
                           type: object
                         tektonWhen:
-                          description: TektonWhen is for conditional execution. Input
-                            can be parameters or results
                           items:
-                            description: WhenExpression allows a PipelineTask to declare
-                              expressions to be evaluated before the Task is run to
-                              determine whether the Task should be executed or skipped
                             properties:
                               input:
-                                description: Input is the string for guard checking
-                                  which can be a static input or an output from a
-                                  parent Task
                                 type: string
                               operator:
-                                description: Operator that represents an Input's relationship
-                                  to the values
                                 type: string
                               values:
-                                description: Values is an array of strings, which
-                                  is compared against the input, for guard checking
-                                  It must be non-empty
                                 items:
                                   type: string
                                 type: array
@@ -5085,44 +2680,17 @@ spec:
                             type: object
                           type: array
                         terminationMessagePath:
-                          description: 'Optional: Path at which the file to which
-                            the container''s termination message will be written is
-                            mounted into the container''s filesystem. Message written
-                            is intended to be brief final status, such as an assertion
-                            failure message. Will be truncated by the node if greater
-                            than 4096 bytes. The total message length across all containers
-                            will be limited to 12kb. Defaults to /dev/termination-log.
-                            Cannot be updated.'
                           type: string
                         terminationMessagePolicy:
-                          description: Indicate how the termination message should
-                            be populated. File will use the contents of terminationMessagePath
-                            to populate the container status message on both success
-                            and failure. FallbackToLogsOnError will use the last chunk
-                            of container log output if the termination message file
-                            is empty and the container exited with an error. The log
-                            output is limited to 2048 bytes or 80 lines, whichever
-                            is smaller. Defaults to File. Cannot be updated.
                           type: string
                         tty:
-                          description: Whether this container should allocate a TTY
-                            for itself, also requires 'stdin' to be true. Default
-                            is false.
                           type: boolean
                         volumeDevices:
-                          description: volumeDevices is the list of block devices
-                            to be used by the container.
                           items:
-                            description: volumeDevice describes a mapping of a raw
-                              block device within a container.
                             properties:
                               devicePath:
-                                description: devicePath is the path inside of the
-                                  container that the device will be mapped to.
                                 type: string
                               name:
-                                description: name must match the name of a persistentVolumeClaim
-                                  in the pod
                                 type: string
                             required:
                             - devicePath
@@ -5130,41 +2698,19 @@ spec:
                             type: object
                           type: array
                         volumeMounts:
-                          description: Pod volumes to mount into the container's filesystem.
-                            Cannot be updated.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
                                 type: string
                             required:
                             - mountPath
@@ -5172,7 +2718,6 @@ spec:
                             type: object
                           type: array
                         when:
-                          description: When is condition for running the job
                           properties:
                             branch:
                               items:
@@ -5192,9 +2737,6 @@ spec:
                               type: array
                           type: object
                         workingDir:
-                          description: Container's working directory. If not specified,
-                            the container runtime's default will be used, which might
-                            be configured in the container image. Cannot be updated.
                           type: string
                       required:
                       - name
@@ -5202,74 +2744,47 @@ spec:
                     type: array
                 type: object
               mergeConfig:
-                description: MergeConfig specifies how to automate the PR merge
                 properties:
                   commitTemplate:
-                    description: CommitTemplate is a message template for a merge
-                      commit. The commit message is compiled as a go template using
-                      blocker.PullRequest object.
                     type: string
                   method:
-                    description: Method is a merge method
                     enum:
                     - squash
                     - merge
                     type: string
                   query:
-                    description: Query is conditions for a open PR to be merged
                     properties:
                       approveRequired:
-                        description: ApproveRequired specifies whether to check github/gitlab's
-                          approval
                         type: boolean
                       authors:
-                        description: Authors specify the required authors of PR to
-                          be merged Authors and SkipAuthors are mutually exclusive
                         items:
                           type: string
                         type: array
                       blockLabels:
-                        description: BlockLabels specify the required labels of PR
-                          to be blocked for merge
                         items:
                           type: string
                         type: array
                       branches:
-                        description: Branches specify the required base branches of
-                          PR to be merged Branches and SkipBranches are mutually exclusive
                         items:
                           type: string
                         type: array
                       checks:
-                        description: Checks are checks needed to be passed for the
-                          PR to be merged. Checks and OptionalChecks are mutually
-                          exclusive
                         items:
                           type: string
                         type: array
                       labels:
-                        description: Labels specify the required labels of PR to be
-                          merged
                         items:
                           type: string
                         type: array
                       optionalChecks:
-                        description: OptionalChecks are checks that are not required.
-                          Checks and OptionalChecks are mutually exclusive
                         items:
                           type: string
                         type: array
                       skipAuthors:
-                        description: SkipAuthors specify the required authors of PR
-                          to be blocked for merge Authors and SkipAuthors are mutually
-                          exclusive
                         items:
                           type: string
                         type: array
                       skipBranches:
-                        description: SkipBranches specify the required base branches
-                          of PR to be blocked for merge Branches and SkipBranches
-                          are mutually exclusive
                         items:
                           type: string
                         type: array
@@ -5278,13 +2793,9 @@ spec:
                 - query
                 type: object
               paramConfig:
-                description: ParamConfig specifies parameter
                 properties:
                   paramDefine:
-                    description: ParamDefine is used to define parameter's spec
                     items:
-                      description: ParameterDefine defines a parameter's name, description
-                        & default values
                       properties:
                         defaultArray:
                           items:
@@ -5301,9 +2812,7 @@ spec:
                       type: object
                     type: array
                   paramValue:
-                    description: ParamValue can specify values of parameters
                     items:
-                      description: ParameterValue defines values of parameter
                       properties:
                         arrayVal:
                           items:
@@ -5319,68 +2828,24 @@ spec:
                     type: array
                 type: object
               podTemplate:
-                description: PodTemplate for the TaskRun pods. Same as tekton's pod
-                  template. Refer to https://github.com/tektoncd/pipeline/blob/master/docs/podtemplates.md
                 properties:
                   affinity:
-                    description: If specified, the pod's scheduling constraints
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node matches the corresponding matchExpressions;
-                              the node(s) with the highest sum are the most preferred.
                             items:
-                              description: An empty preferred scheduling term matches
-                                all objects with implicit weight 0 (i.e. it's a no-op).
-                                A null preferred scheduling term matches no objects
-                                (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -5390,35 +2855,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -5429,8 +2872,6 @@ spec:
                                       type: array
                                   type: object
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -5439,53 +2880,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from
-                              its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term
-                                    matches no objects. The requirements of them are
-                                    ANDed. The TopologySelectorTerm type implements
-                                    a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -5495,35 +2901,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -5539,65 +2923,22 @@ spec:
                             type: object
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5609,54 +2950,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5668,41 +2973,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -5711,56 +2993,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to a pod label update),
-                              the system may or may not try to eventually evict the
-                              pod from its node. When there are multiple elements,
-                              the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5772,53 +3016,18 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5830,32 +3039,13 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -5863,65 +3053,22 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the anti-affinity expressions
-                              specified by this field, but it may choose a node that
-                              violates one or more of the expressions. The node that
-                              is most preferred is the one with the greatest sum of
-                              weights, i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              anti-affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5933,54 +3080,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5992,41 +3103,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -6035,56 +3123,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified
-                              by this field are not met at scheduling time, the pod
-                              will not be scheduled onto the node. If the anti-affinity
-                              requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod
-                              label update), the system may or may not try to eventually
-                              evict the pod from its node. When there are multiple
-                              elements, the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6096,53 +3146,18 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6154,32 +3169,13 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -6188,237 +3184,107 @@ spec:
                         type: object
                     type: object
                   automountServiceAccountToken:
-                    description: AutomountServiceAccountToken indicates whether pods
-                      running as this service account should have an API token automatically
-                      mounted.
                     type: boolean
                   dnsConfig:
-                    description: Specifies the DNS parameters of a pod. Parameters
-                      specified here will be merged to the generated DNS configuration
-                      based on DNSPolicy.
                     properties:
                       nameservers:
-                        description: A list of DNS name server IP addresses. This
-                          will be appended to the base nameservers generated from
-                          DNSPolicy. Duplicated nameservers will be removed.
                         items:
                           type: string
                         type: array
                       options:
-                        description: A list of DNS resolver options. This will be
-                          merged with the base options generated from DNSPolicy. Duplicated
-                          entries will be removed. Resolution options given in Options
-                          will override those that appear in the base DNSPolicy.
                         items:
-                          description: PodDNSConfigOption defines DNS resolver options
-                            of a pod.
                           properties:
                             name:
-                              description: Required.
                               type: string
                             value:
                               type: string
                           type: object
                         type: array
                       searches:
-                        description: A list of DNS search domains for host-name lookup.
-                          This will be appended to the base search paths generated
-                          from DNSPolicy. Duplicated search paths will be removed.
                         items:
                           type: string
                         type: array
                     type: object
                   dnsPolicy:
-                    description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                      Valid values are 'ClusterFirst', 'Default' or 'None'. DNS parameters
-                      given in DNSConfig will be merged with the policy selected with
-                      DNSPolicy.
                     type: string
                   enableServiceLinks:
-                    description: 'EnableServiceLinks indicates whether information
-                      about services should be injected into pod''s environment variables,
-                      matching the syntax of Docker links. Optional: Defaults to true.'
                     type: boolean
                   hostAliases:
-                    description: HostAliases is an optional list of hosts and IPs
-                      that will be injected into the pod's hosts file if specified.
-                      This is only valid for non-hostNetwork pods.
                     items:
-                      description: HostAlias holds the mapping between IP and hostnames
-                        that will be injected as an entry in the pod's hosts file.
                       properties:
                         hostnames:
-                          description: Hostnames for the above IP address.
                           items:
                             type: string
                           type: array
                         ip:
-                          description: IP address of the host file entry.
                           type: string
                       type: object
                     type: array
                   hostNetwork:
-                    description: HostNetwork specifies whether the pod may use the
-                      node network namespace
                     type: boolean
                   imagePullSecrets:
-                    description: ImagePullSecrets gives the name of the secret used
-                      by the pod to pull the image if specified
                     items:
-                      description: LocalObjectReference contains enough information
-                        to let you locate the referenced object inside the same namespace.
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'NodeSelector is a selector which must be true for
-                      the pod to fit on a node. Selector which must match a node''s
-                      labels for the pod to be scheduled on that node. More info:
-                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                     type: object
                   priorityClassName:
-                    description: If specified, indicates the pod's priority. "system-node-critical"
-                      and "system-cluster-critical" are two special keywords which
-                      indicate the highest priorities with the former being the highest
-                      priority. Any other name must be defined by creating a PriorityClass
-                      object with that name. If not specified, the pod priority will
-                      be default or zero if there is no default.
                     type: string
                   runtimeClassName:
-                    description: 'RuntimeClassName refers to a RuntimeClass object
-                      in the node.k8s.io group, which should be used to run this pod.
-                      If no RuntimeClass resource matches the named class, the pod
-                      will not be run. If unset or empty, the "legacy" RuntimeClass
-                      will be used, which is an implicit class with an empty definition
-                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                      This is a beta feature as of Kubernetes v1.14.'
                     type: string
                   schedulerName:
-                    description: SchedulerName specifies the scheduler to be used
-                      to dispatch the Pod
                     type: string
                   securityContext:
-                    description: 'SecurityContext holds pod-level security attributes
-                      and common container settings. Optional: Defaults to empty.  See
-                      type description for default values of each field.'
                     properties:
                       fsGroup:
-                        description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
                         format: int64
                         type: integer
                       fsGroupChangePolicy:
-                        description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
                         type: string
                       runAsGroup:
-                        description: The GID to run the entrypoint of the container
-                          process. Uses runtime default if unset. May also be set
-                          in SecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence for that container.
                         format: int64
                         type: integer
                       runAsNonRoot:
-                        description: Indicates that the container must run as a non-root
-                          user. If true, the Kubelet will validate the image at runtime
-                          to ensure that it does not run as UID 0 (root) and fail
-                          to start the container if it does. If unset or false, no
-                          such validation will be performed. May also be set in SecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
                         type: boolean
                       runAsUser:
-                        description: The UID to run the entrypoint of the container
-                          process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in SecurityContext.  If set
-                          in both SecurityContext and PodSecurityContext, the value
-                          specified in SecurityContext takes precedence for that container.
                         format: int64
                         type: integer
                       seLinuxOptions:
-                        description: The SELinux context to be applied to all containers.
-                          If unspecified, the container runtime will allocate a random
-                          SELinux context for each container.  May also be set in
-                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                          the value specified in SecurityContext takes precedence
-                          for that container.
                         properties:
                           level:
-                            description: Level is SELinux level label that applies
-                              to the container.
                             type: string
                           role:
-                            description: Role is a SELinux role label that applies
-                              to the container.
                             type: string
                           type:
-                            description: Type is a SELinux type label that applies
-                              to the container.
                             type: string
                           user:
-                            description: User is a SELinux user label that applies
-                              to the container.
                             type: string
                         type: object
                       seccompProfile:
-                        description: The seccomp options to use by the containers
-                          in this pod.
                         properties:
                           localhostProfile:
-                            description: localhostProfile indicates a profile defined
-                              in a file on the node should be used. The profile must
-                              be preconfigured on the node to work. Must be a descending
-                              path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
                             type: string
                           type:
-                            description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                             type: string
                         required:
                         - type
                         type: object
                       supplementalGroups:
-                        description: A list of groups applied to the first process
-                          run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
                         items:
                           format: int64
                           type: integer
                         type: array
                       sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used
-                          for the pod. Pods with unsupported sysctls (by the container
-                          runtime) might fail to launch.
                         items:
-                          description: Sysctl defines a kernel parameter to be set
                           properties:
                             name:
-                              description: Name of a property to set
                               type: string
                             value:
-                              description: Value of a property to set
                               type: string
                           required:
                           - name
@@ -6426,307 +3292,132 @@ spec:
                           type: object
                         type: array
                       windowsOptions:
-                        description: The Windows specific settings applied to all
-                          containers. If unspecified, the options within a container's
-                          SecurityContext will be used. If set in both SecurityContext
-                          and PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
                         properties:
                           gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field.
                             type: string
                           gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use.
                             type: string
                           hostProcess:
-                            description: HostProcess determines if a container should
-                              be run as a 'Host Process' container. This field is
-                              alpha-level and will only be honored by components that
-                              enable the WindowsHostProcessContainers feature flag.
-                              Setting this field without the feature flag will result
-                              in errors when validating the Pod. All of a Pod's containers
-                              must have the same effective HostProcess value (it is
-                              not allowed to have a mix of HostProcess containers
-                              and non-HostProcess containers).  In addition, if HostProcess
-                              is true then HostNetwork must also be set to true.
                             type: boolean
                           runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
                             type: string
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   volumes:
-                    description: 'List of volumes that can be mounted by containers
-                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                     items:
-                      description: Volume represents a named volume in a pod that
-                        may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
-                          description: 'AWSElasticBlockStore represents an AWS Disk
-                            resource that is attached to a kubelet''s host machine
-                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty).'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Specify "true" to force and set the ReadOnly
-                                property in VolumeMounts to "true". If omitted, the
-                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: boolean
                             volumeID:
-                              description: 'Unique ID of the persistent disk resource
-                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: AzureDisk represents an Azure Data Disk mount
-                            on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'Host Caching mode: None, Read Only, Read
-                                Write.'
                               type: string
                             diskName:
-                              description: The Name of the data disk in the blob storage
                               type: string
                             diskURI:
-                              description: The URI the data disk in the blob storage
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             kind:
-                              description: 'Expected values Shared: multiple blob
-                                disks per storage account  Dedicated: single blob
-                                disk per storage account  Managed: azure managed data
-                                disk (only in managed availability set). defaults
-                                to shared'
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
-                          description: AzureFile represents an Azure File Service
-                            mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: the name of secret that contains Azure
-                                Storage Account Name and Key
                               type: string
                             shareName:
-                              description: Share Name
                               type: string
                           required:
                           - secretName
                           - shareName
                           type: object
                         cephfs:
-                          description: CephFS represents a Ceph FS mount on the host
-                            that shares a pod's lifetime
                           properties:
                             monitors:
-                              description: 'Required: Monitors is a collection of
-                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             path:
-                              description: 'Optional: Used as the mounted root, rather
-                                than the full Ceph tree, default is /'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: boolean
                             secretFile:
-                              description: 'Optional: SecretFile is the path to key
-                                ring for User, default is /etc/ceph/user.secret More
-                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                authentication secret for User, default is empty.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             user:
-                              description: 'Optional: User is the rados user name,
-                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
-                          description: 'Cinder represents a cinder volume attached
-                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: boolean
                             secretRef:
-                              description: 'Optional: points to a secret object containing
-                                parameters used to connect to OpenStack.'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             volumeID:
-                              description: 'volume id used to identify the volume
-                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
-                          description: ConfigMap represents a configMap that should
-                            populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced ConfigMap will be
-                                projected into the volume as a file whose name is
-                                the key and content is the value. If specified, the
-                                listed keys will be projected into the specified paths,
-                                and unlisted keys will not be present. If a key is
-                                specified which is not present in the ConfigMap, the
-                                volume setup will error unless it is marked optional.
-                                Paths must be relative and may not contain the '..'
-                                path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a
-                                  volume.
                                 properties:
                                   key:
-                                    description: The key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -6734,140 +3425,63 @@ spec:
                                 type: object
                               type: array
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its keys
-                                must be defined
                               type: boolean
                           type: object
                         csi:
-                          description: CSI (Container Storage Interface) represents
-                            ephemeral storage that is handled by certain external
-                            CSI drivers (Beta feature).
                           properties:
                             driver:
-                              description: Driver is the name of the CSI driver that
-                                handles this volume. Consult with your admin for the
-                                correct name as registered in the cluster.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Ex. "ext4", "xfs",
-                                "ntfs". If not provided, the empty value is passed
-                                to the associated CSI driver which will determine
-                                the default filesystem to apply.
                               type: string
                             nodePublishSecretRef:
-                              description: NodePublishSecretRef is a reference to
-                                the secret object containing sensitive information
-                                to pass to the CSI driver to complete the CSI NodePublishVolume
-                                and NodeUnpublishVolume calls. This field is optional,
-                                and  may be empty if no secret is required. If the
-                                secret object contains more than one secret, all secret
-                                references are passed.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             readOnly:
-                              description: Specifies a read-only configuration for
-                                the volume. Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
-                              description: VolumeAttributes stores driver-specific
-                                properties that are passed to the CSI driver. Consult
-                                your driver's documentation for supported values.
                               type: object
                           required:
                           - driver
                           type: object
                         downwardAPI:
-                          description: DownwardAPI represents downward API about the
-                            pod that should populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits to use on created
-                                files by default. Must be a Optional: mode bits used
-                                to set permissions on created files by default. Must
-                                be an octal value between 0000 and 0777 or a decimal
-                                value between 0 and 511. YAML accepts both octal and
-                                decimal values, JSON requires decimal values for mode
-                                bits. Defaults to 0644. Directories within the path
-                                are not affected by this setting. This might be in
-                                conflict with other options that affect the file mode,
-                                like fsGroup, and the result can be other mode bits
-                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: Items is a list of downward API volume
-                                file
                               items:
-                                description: DownwardAPIVolumeFile represents information
-                                  to create the file containing the pod field
                                 properties:
                                   fieldRef:
-                                    description: 'Required: Selects a field of the
-                                      pod: only annotations, labels, name and namespace
-                                      are supported.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file, must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: 'Required: Path is  the relative
-                                      path name of the file to be created. Must not
-                                      be absolute or contain the ''..'' path. Must
-                                      be utf-8 encoded. The first item of the relative
-                                      path must not start with ''..'''
                                     type: string
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, requests.cpu and requests.memory)
-                                      are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
-                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
@@ -6878,176 +3492,53 @@ spec:
                               type: array
                           type: object
                         emptyDir:
-                          description: 'EmptyDir represents a temporary directory
-                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           properties:
                             medium:
-                              description: 'What type of storage medium should back
-                                this directory. The default is "" which means to use
-                                the node''s default medium. Must be an empty string
-                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Total amount of local storage required
-                                for this EmptyDir volume. The size limit is also applicable
-                                for memory medium. The maximum usage on memory medium
-                                EmptyDir would be the minimum value between the SizeLimit
-                                specified here and the sum of memory limits of all
-                                containers in a pod. The default is nil which means
-                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
-                          description: "Ephemeral represents a volume that is handled
-                            by a cluster storage driver. The volume's lifecycle is
-                            tied to the pod that defines it - it will be created before
-                            the pod starts, and deleted when the pod is removed. \n
-                            Use this if: a) the volume is only needed while the pod
-                            runs, b) features of normal volumes like restoring from
-                            snapshot or capacity    tracking are needed, c) the storage
-                            driver is specified through a storage class, and d) the
-                            storage driver supports dynamic volume provisioning through
-                            \   a PersistentVolumeClaim (see EphemeralVolumeSource
-                            for more    information on the connection between this
-                            volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                            or one of the vendor-specific APIs for volumes that persist
-                            for longer than the lifecycle of an individual pod. \n
-                            Use CSI for light-weight local ephemeral volumes if the
-                            CSI driver is meant to be used that way - see the documentation
-                            of the driver for more information. \n A pod can use both
-                            types of ephemeral volumes and persistent volumes at the
-                            same time. \n This is a beta feature and only available
-                            when the GenericEphemeralVolume feature gate is enabled."
                           properties:
                             volumeClaimTemplate:
-                              description: "Will be used to create a stand-alone PVC
-                                to provision the volume. The pod in which this EphemeralVolumeSource
-                                is embedded will be the owner of the PVC, i.e. the
-                                PVC will be deleted together with the pod.  The name
-                                of the PVC will be `<pod name>-<volume name>` where
-                                `<volume name>` is the name from the `PodSpec.Volumes`
-                                array entry. Pod validation will reject the pod if
-                                the concatenated name is not valid for a PVC (for
-                                example, too long). \n An existing PVC with that name
-                                that is not owned by the pod will *not* be used for
-                                the pod to avoid using an unrelated volume by mistake.
-                                Starting the pod is then blocked until the unrelated
-                                PVC is removed. If such a pre-created PVC is meant
-                                to be used by the pod, the PVC has to updated with
-                                an owner reference to the pod once the pod exists.
-                                Normally this should not be necessary, but it may
-                                be useful when manually reconstructing a broken cluster.
-                                \n This field is read-only and no changes will be
-                                made by Kubernetes to the PVC after it has been created.
-                                \n Required, must not be nil."
                               properties:
                                 metadata:
-                                  description: May contain labels and annotations
-                                    that will be copied into the PVC when creating
-                                    it. No other fields are allowed and will be rejected
-                                    during validation.
                                   type: object
                                 spec:
-                                  description: The specification for the PersistentVolumeClaim.
-                                    The entire content is copied unchanged into the
-                                    PVC that gets created from this template. The
-                                    same fields as in a PersistentVolumeClaim are
-                                    also valid here.
                                   properties:
                                     accessModes:
-                                      description: 'AccessModes contains the desired
-                                        access modes the volume should have. More
-                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'This field can be used to specify
-                                        either: * An existing VolumeSnapshot object
-                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
-                                        An existing PVC (PersistentVolumeClaim) If
-                                        the provisioner or an external controller
-                                        can support the specified data source, it
-                                        will create a new volume based on the contents
-                                        of the specified data source. If the AnyVolumeDataSource
-                                        feature gate is enabled, this field will always
-                                        have the same contents as the DataSourceRef
-                                        field.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the
-                                            resource being referenced. If APIGroup
-                                            is not specified, the specified Kind must
-                                            be in the core API group. For any other
-                                            third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource
-                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource
-                                            being referenced
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     dataSourceRef:
-                                      description: 'Specifies the object from which
-                                        to populate the volume with data, if a non-empty
-                                        volume is desired. This may be any local object
-                                        from a non-empty API group (non core object)
-                                        or a PersistentVolumeClaim object. When this
-                                        field is specified, volume binding will only
-                                        succeed if the type of the specified object
-                                        matches some installed volume populator or
-                                        dynamic provisioner. This field will replace
-                                        the functionality of the DataSource field
-                                        and as such if both fields are non-empty,
-                                        they must have the same value. For backwards
-                                        compatibility, both fields (DataSource and
-                                        DataSourceRef) will be set to the same value
-                                        automatically if one of them is empty and
-                                        the other is non-empty. There are two important
-                                        differences between DataSource and DataSourceRef:
-                                        * While DataSource only allows two specific
-                                        types of objects, DataSourceRef   allows any
-                                        non-core object, as well as PersistentVolumeClaim
-                                        objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef   preserves
-                                        all values, and generates an error if a disallowed
-                                        value is   specified. (Alpha) Using this field
-                                        requires the AnyVolumeDataSource feature gate
-                                        to be enabled.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the
-                                            resource being referenced. If APIGroup
-                                            is not specified, the specified Kind must
-                                            be in the core API group. For any other
-                                            third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource
-                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource
-                                            being referenced
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
-                                      description: 'Resources represents the minimum
-                                        resources the volume should have. More info:
-                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -7056,9 +3547,6 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -7067,47 +3555,18 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     selector:
-                                      description: A label query over volumes to consider
-                                        for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7119,27 +3578,13 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     storageClassName:
-                                      description: 'Name of the StorageClass required
-                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of
-                                        volume is required by the claim. Value of
-                                        Filesystem is implied when not included in
-                                        claim spec.
                                       type: string
                                     volumeName:
-                                      description: VolumeName is the binding reference
-                                        to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -7147,257 +3592,125 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: FC represents a Fibre Channel resource that
-                            is attached to a kubelet's host machine and then exposed
-                            to the pod.
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified. TODO: how do we prevent errors in the
-                                filesystem from compromising the machine'
                               type: string
                             lun:
-                              description: 'Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                               type: boolean
                             targetWWNs:
-                              description: 'Optional: FC target worldwide names (WWNs)'
                               items:
                                 type: string
                               type: array
                             wwids:
-                              description: 'Optional: FC volume world wide identifiers
-                                (wwids) Either wwids or combination of targetWWNs
-                                and lun must be set, but not both simultaneously.'
                               items:
                                 type: string
                               type: array
                           type: object
                         flexVolume:
-                          description: FlexVolume represents a generic volume resource
-                            that is provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: Driver is the name of the driver to use
-                                for this volume.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". The default filesystem depends on FlexVolume
-                                script.
                               type: string
                             options:
                               additionalProperties:
                                 type: string
-                              description: 'Optional: Extra command options if any.'
                               type: object
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                               type: boolean
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                secret object containing sensitive information to
-                                pass to the plugin scripts. This may be empty if no
-                                secret object is specified. If the secret object contains
-                                more than one secret, all secrets are passed to the
-                                plugin scripts.'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                           required:
                           - driver
                           type: object
                         flocker:
-                          description: Flocker represents a Flocker volume attached
-                            to a kubelet's host machine. This depends on the Flocker
-                            control service being running
                           properties:
                             datasetName:
-                              description: Name of the dataset stored as metadata
-                                -> name on the dataset for Flocker should be considered
-                                as deprecated
                               type: string
                             datasetUUID:
-                              description: UUID of the dataset. This is unique identifier
-                                of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
-                          description: 'GCEPersistentDisk represents a GCE Disk resource
-                            that is attached to a kubelet''s host machine and then
-                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               format: int32
                               type: integer
                             pdName:
-                              description: 'Unique name of the PD resource in GCE.
-                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
-                                setting in VolumeMounts. Defaults to false. More info:
-                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: boolean
                           required:
                           - pdName
                           type: object
                         gitRepo:
-                          description: 'GitRepo represents a git repository at a particular
-                            revision. DEPRECATED: GitRepo is deprecated. To provision
-                            a container with a git repo, mount an EmptyDir into an
-                            InitContainer that clones the repo using git, then mount
-                            the EmptyDir into the Pod''s container.'
                           properties:
                             directory:
-                              description: Target directory name. Must not contain
-                                or start with '..'.  If '.' is supplied, the volume
-                                directory will be the git repository.  Otherwise,
-                                if specified, the volume will contain the git repository
-                                in the subdirectory with the given name.
                               type: string
                             repository:
-                              description: Repository URL
                               type: string
                             revision:
-                              description: Commit hash for the specified revision.
                               type: string
                           required:
                           - repository
                           type: object
                         glusterfs:
-                          description: 'Glusterfs represents a Glusterfs mount on
-                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                           properties:
                             endpoints:
-                              description: 'EndpointsName is the endpoint name that
-                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             path:
-                              description: 'Path is the Glusterfs volume path. More
-                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the Glusterfs
-                                volume to be mounted with read-only permissions. Defaults
-                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: boolean
                           required:
                           - endpoints
                           - path
                           type: object
                         hostPath:
-                          description: 'HostPath represents a pre-existing file or
-                            directory on the host machine that is directly exposed
-                            to the container. This is generally used for system agents
-                            or other privileged things that are allowed to see the
-                            host machine. Most containers will NOT need this. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                            --- TODO(jonesdl) We need to restrict who can use host
-                            directory mounts and who can/can not mount host directories
-                            as read/write.'
                           properties:
                             path:
-                              description: 'Path of the directory on the host. If
-                                the path is a symlink, it will follow the link to
-                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                             type:
-                              description: 'Type for HostPath Volume Defaults to ""
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
-                          description: 'ISCSI represents an ISCSI Disk resource that
-                            is attached to a kubelet''s host machine and then exposed
-                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                           properties:
                             chapAuthDiscovery:
-                              description: whether support iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
-                              description: whether support iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             initiatorName:
-                              description: Custom iSCSI Initiator Name. If initiatorName
-                                is specified with iscsiInterface simultaneously, new
-                                iSCSI interface <target portal>:<volume name> will
-                                be created for the connection.
                               type: string
                             iqn:
-                              description: Target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
-                              description: iSCSI Interface Name that uses an iSCSI
-                                transport. Defaults to 'default' (tcp).
                               type: string
                             lun:
-                              description: iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
-                              description: iSCSI Target Portal List. The portal is
-                                either an IP or ip_addr:port if the port is other
-                                than default (typically TCP ports 860 and 3260).
                               items:
                                 type: string
                               type: array
                             readOnly:
-                              description: ReadOnly here will force the ReadOnly setting
-                                in VolumeMounts. Defaults to false.
                               type: boolean
                             secretRef:
-                              description: CHAP Secret for iSCSI target and initiator
-                                authentication
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             targetPortal:
-                              description: iSCSI Target Portal. The Portal is either
-                                an IP or ip_addr:port if the port is other than default
-                                (typically TCP ports 860 and 3260).
                               type: string
                           required:
                           - iqn
@@ -7405,153 +3718,67 @@ spec:
                           - targetPortal
                           type: object
                         name:
-                          description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         nfs:
-                          description: 'NFS represents an NFS mount on the host that
-                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           properties:
                             path:
-                              description: 'Path that is exported by the NFS server.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the NFS export
-                                to be mounted with read-only permissions. Defaults
-                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: boolean
                             server:
-                              description: 'Server is the hostname or IP address of
-                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                           required:
                           - path
                           - server
                           type: object
                         persistentVolumeClaim:
-                          description: 'PersistentVolumeClaimVolumeSource represents
-                            a reference to a PersistentVolumeClaim in the same namespace.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             claimName:
-                              description: 'ClaimName is the name of a PersistentVolumeClaim
-                                in the same namespace as the pod using this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               type: string
                             readOnly:
-                              description: Will force the ReadOnly setting in VolumeMounts.
-                                Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: PhotonPersistentDisk represents a PhotonController
-                            persistent disk attached and mounted on kubelets host
-                            machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             pdID:
-                              description: ID that identifies Photon Controller persistent
-                                disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: PortworxVolume represents a portworx volume
-                            attached and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: FSType represents the filesystem type to
-                                mount Must be a filesystem type supported by the host
-                                operating system. Ex. "ext4", "xfs". Implicitly inferred
-                                to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: VolumeID uniquely identifies a Portworx
-                                volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: Items for all in one resources secrets, configmaps,
-                            and downward API
                           properties:
                             defaultMode:
-                              description: Mode bits used to set permissions on created
-                                files by default. Must be an octal value between 0000
-                                and 0777 or a decimal value between 0 and 511. YAML
-                                accepts both octal and decimal values, JSON requires
-                                decimal values for mode bits. Directories within the
-                                path are not affected by this setting. This might
-                                be in conflict with other options that affect the
-                                file mode, like fsGroup, and the result can be other
-                                mode bits set.
                               format: int32
                               type: integer
                             sources:
-                              description: list of volume projections
                               items:
-                                description: Projection that may be projected along
-                                  with other supported volume types
                                 properties:
                                   configMap:
-                                    description: information about the configMap data
-                                      to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path
-                                            within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -7559,92 +3786,40 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
                                         type: boolean
                                     type: object
                                   downwardAPI:
-                                    description: information about the downwardAPI
-                                      data to project
                                     properties:
                                       items:
-                                        description: Items is a list of DownwardAPIVolume
-                                          file
                                         items:
-                                          description: DownwardAPIVolumeFile represents
-                                            information to create the file containing
-                                            the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field
-                                                of the pod: only annotations, labels,
-                                                name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema
-                                                    the FieldPath is written in terms
-                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to
-                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the
-                                                relative path name of the file to
-                                                be created. Must not be absolute or
-                                                contain the ''..'' path. Must be utf-8
-                                                encoded. The first item of the relative
-                                                path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required
-                                                    for volumes, optional for env
-                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output
-                                                    format of the exposed resources,
-                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource
-                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -7655,50 +3830,16 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: information about the secret data
-                                      to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path
-                                            within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -7706,45 +3847,18 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
                                         type: boolean
                                     type: object
                                   serviceAccountToken:
-                                    description: information about the serviceAccountToken
-                                      data to project
                                     properties:
                                       audience:
-                                        description: Audience is the intended audience
-                                          of the token. A recipient of a token must
-                                          identify itself with an identifier specified
-                                          in the audience of the token, and otherwise
-                                          should reject the token. The audience defaults
-                                          to the identifier of the apiserver.
                                         type: string
                                       expirationSeconds:
-                                        description: ExpirationSeconds is the requested
-                                          duration of validity of the service account
-                                          token. As the token approaches expiration,
-                                          the kubelet volume plugin will proactively
-                                          rotate the service account token. The kubelet
-                                          will start trying to rotate the token if
-                                          the token is older than 80 percent of its
-                                          time to live or if the token is older than
-                                          24 hours.Defaults to 1 hour and must be
-                                          at least 10 minutes.
                                         format: int64
                                         type: integer
                                       path:
-                                        description: Path is the path relative to
-                                          the mount point of the file to project the
-                                          token into.
                                         type: string
                                     required:
                                     - path
@@ -7753,148 +3867,74 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: Quobyte represents a Quobyte mount on the host
-                            that shares a pod's lifetime
                           properties:
                             group:
-                              description: Group to map volume access to Default is
-                                no group
                               type: string
                             readOnly:
-                              description: ReadOnly here will force the Quobyte volume
-                                to be mounted with read-only permissions. Defaults
-                                to false.
                               type: boolean
                             registry:
-                              description: Registry represents a single or multiple
-                                Quobyte Registry services specified as a string as
-                                host:port pair (multiple entries are separated with
-                                commas) which acts as the central registry for volumes
                               type: string
                             tenant:
-                              description: Tenant owning the given Quobyte volume
-                                in the Backend Used with dynamically provisioned Quobyte
-                                volumes, value is set by the plugin
                               type: string
                             user:
-                              description: User to map volume access to Defaults to
-                                serivceaccount user
                               type: string
                             volume:
-                              description: Volume is a string that references an already
-                                created Quobyte volume by name.
                               type: string
                           required:
                           - registry
                           - volume
                           type: object
                         rbd:
-                          description: 'RBD represents a Rados Block Device mount
-                            on the host that shares a pod''s lifetime. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             image:
-                              description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             keyring:
-                              description: 'Keyring is the path to key ring for RBDUser.
-                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             monitors:
-                              description: 'A collection of Ceph monitors. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             pool:
-                              description: 'The rados pool name. Default is rbd. More
-                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
-                                setting in VolumeMounts. Defaults to false. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: boolean
                             secretRef:
-                              description: 'SecretRef is name of the authentication
-                                secret for RBDUser. If provided overrides keyring.
-                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             user:
-                              description: 'The rados user name. Default is admin.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
-                          description: ScaleIO represents a ScaleIO persistent volume
-                            attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Default is "xfs".
                               type: string
                             gateway:
-                              description: The host address of the ScaleIO API Gateway.
                               type: string
                             protectionDomain:
-                              description: The name of the ScaleIO Protection Domain
-                                for the configured storage.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef references to the secret for
-                                ScaleIO user and other sensitive information. If this
-                                is not provided, Login operation will fail.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             sslEnabled:
-                              description: Flag to enable/disable SSL communication
-                                with Gateway, default false
                               type: boolean
                             storageMode:
-                              description: Indicates whether the storage for a volume
-                                should be ThickProvisioned or ThinProvisioned. Default
-                                is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: The ScaleIO Storage Pool associated with
-                                the protection domain.
                               type: string
                             system:
-                              description: The name of the storage system as configured
-                                in ScaleIO.
                               type: string
                             volumeName:
-                              description: The name of a volume already created in
-                                the ScaleIO system that is associated with this volume
-                                source.
                               type: string
                           required:
                           - gateway
@@ -7902,57 +3942,19 @@ spec:
                           - system
                           type: object
                         secret:
-                          description: 'Secret represents a secret that should populate
-                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be
-                                relative and may not contain the '..' path or start
-                                with '..'.
                               items:
-                                description: Maps a string key to a path within a
-                                  volume.
                                 properties:
                                   key:
-                                    description: The key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -7960,76 +3962,35 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: Specify whether the Secret or its keys
-                                must be defined
                               type: boolean
                             secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
                         storageos:
-                          description: StorageOS represents a StorageOS volume attached
-                            and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef specifies the secret to use for
-                                obtaining the StorageOS API credentials.  If not specified,
-                                default values will be attempted.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             volumeName:
-                              description: VolumeName is the human-readable name of
-                                the StorageOS volume.  Volume names are only unique
-                                within a namespace.
                               type: string
                             volumeNamespace:
-                              description: VolumeNamespace specifies the scope of
-                                the volume within StorageOS.  If no namespace is specified
-                                then the Pod's namespace will be used.  This allows
-                                the Kubernetes name scoping to be mirrored within
-                                StorageOS for tighter integration. Set VolumeName
-                                to any name to override the default behaviour. Set
-                                to "default" if you are not using namespaces within
-                                StorageOS. Namespaces that do not pre-exist within
-                                StorageOS will be created.
                               type: string
                           type: object
                         vsphereVolume:
-                          description: VsphereVolume represents a vSphere volume attached
-                            and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             storagePolicyID:
-                              description: Storage Policy Based Management (SPBM)
-                                profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: Storage Policy Based Management (SPBM)
-                                profile name.
                               type: string
                             volumePath:
-                              description: Path that identifies vSphere volume vmdk
                               type: string
                           required:
                           - volumePath
@@ -8040,81 +4001,34 @@ spec:
                     type: array
                 type: object
               secrets:
-                description: Secrets are the list of secret names which are included
-                  in service account
                 items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               tlsConfig:
-                description: TLSConfig set tls configurations
                 properties:
                   insecureSkipVerify:
-                    description: InsecureSkipVerify is flag for accepting any certificate
-                      presented by the server and any host name in that certificate.
                     type: boolean
                 type: object
               workspaces:
-                description: Workspaces list
                 items:
-                  description: WorkspaceBinding maps a Task's declared workspace to
-                    a Volume.
                   properties:
                     configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this workspace.
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -8122,109 +4036,46 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
                           type: boolean
                       type: object
                     emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
-                        Either this OR PersistentVolumeClaim can be used.'
                       properties:
                         medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     name:
-                      description: Name is the name of the workspace populated by
-                        the volume.
                       type: string
                     persistentVolumeClaim:
-                      description: PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        Either this OR EmptyDir can be used.
                       properties:
                         claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     secret:
-                      description: Secret represents a secret that should populate
-                        this workspace.
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -8232,124 +4083,51 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
                           type: boolean
                         secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     subPath:
-                      description: SubPath is optionally a directory on the volume
-                        which should be used for this binding (i.e. the volume will
-                        be mounted at this sub directory).
                       type: string
                     volumeClaimTemplate:
-                      description: VolumeClaimTemplate is a template for a claim that
-                        will be created in the same namespace. The PipelineRun controller
-                        is responsible for creating a unique claim for each instance
-                        of PipelineRun.
                       properties:
                         apiVersion:
-                          description: 'APIVersion defines the versioned schema of
-                            this representation of an object. Servers should convert
-                            recognized schemas to the latest internal value, and may
-                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                           type: string
                         kind:
-                          description: 'Kind is a string value representing the REST
-                            resource this object represents. Servers may infer this
-                            from the endpoint the client submits requests to. Cannot
-                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                           type: string
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Spec defines the desired characteristics of
-                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             accessModes:
-                              description: 'AccessModes contains the desired access
-                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'This field can be used to specify either:
-                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                * An existing PVC (PersistentVolumeClaim) If the provisioner
-                                or an external controller can support the specified
-                                data source, it will create a new volume based on
-                                the contents of the specified data source. If the
-                                AnyVolumeDataSource feature gate is enabled, this
-                                field will always have the same contents as the DataSourceRef
-                                field.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being
-                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being
-                                    referenced
                                   type: string
                               required:
                               - kind
                               - name
                               type: object
                             dataSourceRef:
-                              description: 'Specifies the object from which to populate
-                                the volume with data, if a non-empty volume is desired.
-                                This may be any local object from a non-empty API
-                                group (non core object) or a PersistentVolumeClaim
-                                object. When this field is specified, volume binding
-                                will only succeed if the type of the specified object
-                                matches some installed volume populator or dynamic
-                                provisioner. This field will replace the functionality
-                                of the DataSource field and as such if both fields
-                                are non-empty, they must have the same value. For
-                                backwards compatibility, both fields (DataSource and
-                                DataSourceRef) will be set to the same value automatically
-                                if one of them is empty and the other is non-empty.
-                                There are two important differences between DataSource
-                                and DataSourceRef: * While DataSource only allows
-                                two specific types of objects, DataSourceRef   allows
-                                any non-core object, as well as PersistentVolumeClaim
-                                objects. * While DataSource ignores disallowed values
-                                (dropping them), DataSourceRef   preserves all values,
-                                and generates an error if a disallowed value is   specified.
-                                (Alpha) Using this field requires the AnyVolumeDataSource
-                                feature gate to be enabled.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being
-                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being
-                                    referenced
                                   type: string
                               required:
                               - kind
                               - name
                               type: object
                             resources:
-                              description: 'Resources represents the minimum resources
-                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -8358,8 +4136,6 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -8368,41 +4144,18 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
                             selector:
-                              description: A label query over volumes to consider
-                                for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -8414,35 +4167,18 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
                                   type: object
                               type: object
                             storageClassName:
-                              description: 'Name of the StorageClass required by the
-                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume
-                                is required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
                               type: string
                             volumeName:
-                              description: VolumeName is the binding reference to
-                                the PersistentVolume backing this claim.
                               type: string
                           type: object
                         status:
-                          description: 'Status represents the current information/status
-                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             accessModes:
-                              description: 'AccessModes contains the actual access
-                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
@@ -8453,42 +4189,23 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Represents the actual resources of the
-                                underlying volume.
                               type: object
                             conditions:
-                              description: Current Condition of persistent volume
-                                claim. If underlying persistent volume is being resized
-                                then the Condition will be set to 'ResizeStarted'.
                               items:
-                                description: PersistentVolumeClaimCondition contails
-                                  details about state of pvc
                                 properties:
                                   lastProbeTime:
-                                    description: Last time we probed the condition.
                                     format: date-time
                                     type: string
                                   lastTransitionTime:
-                                    description: Last time the condition transitioned
-                                      from one status to another.
                                     format: date-time
                                     type: string
                                   message:
-                                    description: Human-readable message indicating
-                                      details about last transition.
                                     type: string
                                   reason:
-                                    description: Unique, this should be a short, machine
-                                      understandable string that gives the reason
-                                      for condition's last transition. If it reports
-                                      "ResizeStarted" that means the underlying persistent
-                                      volume is being resized.
                                     type: string
                                   status:
                                     type: string
                                   type:
-                                    description: PersistentVolumeClaimConditionType
-                                      is a valid value of PersistentVolumeClaimCondition.Type
                                     type: string
                                 required:
                                 - status
@@ -8496,7 +4213,6 @@ spec:
                                 type: object
                               type: array
                             phase:
-                              description: Phase represents the current phase of PersistentVolumeClaim.
                               type: string
                           type: object
                       type: object
@@ -8509,67 +4225,32 @@ spec:
             - jobs
             type: object
           status:
-            description: IntegrationConfigStatus defines the observed state of IntegrationConfig
             properties:
               conditions:
-                description: Conditions of IntegrationConfig
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/cicd.tmax.io_integrationjobs.yaml
+++ b/config/crd/cicd.tmax.io_integrationjobs.yaml
@@ -38,57 +38,38 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: IntegrationJob is the Schema for the integrationjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: IntegrationJobSpec defines the desired state of IntegrationJob
             properties:
               configRef:
-                description: ConfigRef refers to the corresponding IntegrationConfig
                 properties:
                   name:
                     type: string
                   type:
-                    description: JobType is a type of Job
                     type: string
                 required:
                 - name
                 - type
                 type: object
               id:
-                description: ID is a unique random string for the IntegrationJob
                 type: string
               jobs:
-                description: Jobs are the tasks to be executed
                 items:
-                  description: Job is a specification of the job to be executed for
-                    specific events Same level of task of tekton
                   properties:
                     after:
-                      description: After configures which jobs should be executed
-                        before this job runs
                       items:
                         type: string
                       type: array
                     approval:
-                      description: Approval
                       properties:
                         approvers:
-                          description: Approvers is a list of approvers
                           items:
-                            description: ApprovalUser is a user
                             properties:
                               email:
                                 type: string
@@ -99,177 +80,90 @@ spec:
                             type: object
                           type: array
                         approversConfigMap:
-                          description: ApproversConfigMap is a configMap Name containing
-                            approvers list should exist in configMap's 'approvers'
-                            key, as comma(,) separated list e.g., admin-tmax.co.kr=sunghyun_kim3@tmax.co.kr,test-tmax.co.kr=kyunghoon_min@tmax.co.kr
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         requestMessage:
-                          description: RequestMessage is a message to be sent to approvers
-                            by email
                           type: string
                       required:
                       - requestMessage
                       type: object
                     args:
-                      description: 'Arguments to the entrypoint. The docker image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell.
-                        The docker image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     email:
-                      description: Email sends email
                       properties:
                         content:
-                          description: Content of the email
                           type: string
                         isHtml:
-                          description: IsHTML describes if it's html content. Default
-                            is false
                           type: boolean
                         receivers:
-                          description: Receivers is a list of email receivers
                           items:
                             type: string
                           type: array
                         title:
-                          description: Title of the email
                           type: string
                       required:
                       - content
                       - title
                       type: object
                     env:
-                      description: List of environment variables to set in the container.
-                        Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or
-                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -280,108 +174,51 @@ spec:
                         type: object
                       type: array
                     envFrom:
-                      description: List of sources to populate environment variables
-                        in the container. The keys defined within a source must be
-                        a C_IDENTIFIER. All invalid keys will be reported as an event
-                        when the container is starting. When a key exists in multiple
-                        sources, the value associated with the last source will take
-                        precedence. Values defined by an Env with a duplicate key
-                        will take precedence. Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set
-                          of ConfigMaps
                         properties:
                           configMapRef:
-                            description: The ConfigMap to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be
-                                  defined
                                 type: boolean
                             type: object
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
-                            description: The Secret to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                         type: object
                       type: array
                     image:
-                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
                       type: string
                     imagePullPolicy:
-                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                       type: string
                     lifecycle:
-                      description: Actions that the management system should take
-                        in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -389,96 +226,49 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The reason for termination is passed
-                            to the handler. The Pod''s termination grace period countdown
-                            begins before the PreStop hooked is executed. Regardless
-                            of the outcome of the handler, the container will eventually
-                            terminate within the Pod''s termination grace period.
-                            Other management of the container blocks until the hook
-                            completes or until the termination grace period is reached.
-                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -486,39 +276,25 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -526,53 +302,27 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
-                      description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be
-                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -580,130 +330,72 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a
-                            TCP port. TCP hooks not yet supported TODO: implement
-                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     name:
-                      description: Name of the container specified as a DNS_LABEL.
-                        Each container in a pod must have a unique name (DNS_LABEL).
-                        Cannot be updated.
                       type: string
                     notification:
-                      description: Notification sends notification when success/fail
                       properties:
                         onFailure:
-                          description: OnFailure notifies when the job is failed
                           properties:
                             email:
-                              description: Email sends email
                               properties:
                                 content:
-                                  description: Content of the email
                                   type: string
                                 isHtml:
-                                  description: IsHTML describes if it's html content.
-                                    Default is false
                                   type: boolean
                                 receivers:
-                                  description: Receivers is a list of email receivers
                                   items:
                                     type: string
                                   type: array
                                 title:
-                                  description: Title of the email
                                   type: string
                               required:
                               - content
                               - title
                               type: object
                             slack:
-                              description: Slack sends slack
                               properties:
                                 message:
-                                  description: Message is a message sent to the webhook.
-                                    It should be a Markdown format. You can use $INTEGRATION_JOB_NAME
-                                    and $JOB_NAME variable for IntegrationJob's name
-                                    and the job's name respectively.
                                   type: string
                                 url:
-                                  description: URL is a webhook url of a slack app.
-                                    Refer to https://api.slack.com/messaging/webhooks
                                   type: string
                               required:
                               - message
@@ -711,42 +403,28 @@ spec:
                               type: object
                           type: object
                         onSuccess:
-                          description: OnSuccess notifies when the job is succeeded
                           properties:
                             email:
-                              description: Email sends email
                               properties:
                                 content:
-                                  description: Content of the email
                                   type: string
                                 isHtml:
-                                  description: IsHTML describes if it's html content.
-                                    Default is false
                                   type: boolean
                                 receivers:
-                                  description: Receivers is a list of email receivers
                                   items:
                                     type: string
                                   type: array
                                 title:
-                                  description: Title of the email
                                   type: string
                               required:
                               - content
                               - title
                               type: object
                             slack:
-                              description: Slack sends slack
                               properties:
                                 message:
-                                  description: Message is a message sent to the webhook.
-                                    It should be a Markdown format. You can use $INTEGRATION_JOB_NAME
-                                    and $JOB_NAME variable for IntegrationJob's name
-                                    and the job's name respectively.
                                   type: string
                                 url:
-                                  description: URL is a webhook url of a slack app.
-                                    Refer to https://api.slack.com/messaging/webhooks
                                   type: string
                               required:
                               - message
@@ -755,42 +433,20 @@ spec:
                           type: object
                       type: object
                     ports:
-                      description: List of ports to expose from the container. Exposing
-                        a port here gives the system additional information about
-                        the network connections a container uses, but is primarily
-                        informational. Not specifying a port here DOES NOT prevent
-                        that port from being exposed. Any port which is listening
-                        on the default "0.0.0.0" address inside a container will be
-                        accessible from the network. Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a
-                          single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP
-                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
-                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If
-                              specified, this must be a valid port number, 0 < x <
-                              65536. If HostNetwork is specified, this must match
-                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME
-                              and unique within the pod. Each named port in a pod
-                              must have a unique name. Name for the port that can
-                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP.
-                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -801,53 +457,27 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
-                      description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be
-                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -855,88 +485,46 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a
-                            TCP port. TCP hooks not yet supported TODO: implement
-                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     resources:
-                      description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       properties:
                         limits:
                           additionalProperties:
@@ -945,8 +533,6 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -955,272 +541,116 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     results:
-                      description: Results emitted by task, which also can be used
-                        as TektonWhen input value.
                       items:
-                        description: TaskResult used to describe the results of a
-                          task
                         properties:
                           description:
-                            description: Description is a human-readable description
-                              of the result
                             type: string
                           name:
-                            description: Name the given name
                             type: string
                         required:
                         - name
                         type: object
                       type: array
                     script:
-                      description: Script will override command of container
                       type: string
                     securityContext:
-                      description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN'
                           type: boolean
                         capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by
-                            the container runtime.
                           properties:
                             add:
-                              description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
                                 type: string
                               type: array
                             drop:
-                              description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
-                          description: Run container in privileged mode. Processes
-                            in privileged containers are essentially equivalent to
-                            root on the host. Defaults to false.
                           type: boolean
                         procMount:
-                          description: procMount denotes the type of proc mount to
-                            use for the containers. The default is DefaultProcMount
-                            which uses the container runtime defaults for readonly
-                            paths and masked paths. This requires the ProcMountType
-                            feature flag to be enabled.
                           type: string
                         readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root
-                            filesystem. Default is false.
                           type: boolean
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a
-                            non-root user. If true, the Kubelet will validate the
-                            image at runtime to ensure that it does not run as UID
-                            0 (root) and fail to start the container if it does. If
-                            unset or false, no such validation will be performed.
-                            May also be set in PodSecurityContext.  If set in both
-                            SecurityContext and PodSecurityContext, the value specified
-                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a
-                            random SELinux context for each container.  May also be
-                            set in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile
-                                must be preconfigured on the node to work. Must be
-                                a descending path, relative to the kubelet's configured
-                                seccomp profile location. Must only be set if type
-                                is "Localhost".
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             hostProcess:
-                              description: HostProcess determines if a container should
-                                be run as a 'Host Process' container. This field is
-                                alpha-level and will only be honored by components
-                                that enable the WindowsHostProcessContainers feature
-                                flag. Setting this field without the feature flag
-                                will result in errors when validating the Pod. All
-                                of a Pod's containers must have the same effective
-                                HostProcess value (it is not allowed to have a mix
-                                of HostProcess containers and non-HostProcess containers).  In
-                                addition, if HostProcess is true then HostNetwork
-                                must also be set to true.
                               type: boolean
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set
-                                in PodSecurityContext. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     skipCheckout:
-                      description: SkipCheckout describes whether or not to checkout
-                        from git before
                       type: boolean
                     slack:
-                      description: Slack sends slack
                       properties:
                         message:
-                          description: Message is a message sent to the webhook. It
-                            should be a Markdown format. You can use $INTEGRATION_JOB_NAME
-                            and $JOB_NAME variable for IntegrationJob's name and the
-                            job's name respectively.
                           type: string
                         url:
-                          description: URL is a webhook url of a slack app. Refer
-                            to https://api.slack.com/messaging/webhooks
                           type: string
                       required:
                       - message
                       - url
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: One and only one of the following should be
-                            specified. Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1228,111 +658,53 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a
-                            TCP port. TCP hooks not yet supported TODO: implement
-                            a realistic TCP lifecycle hook'
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     stdin:
-                      description: Whether this container should allocate a buffer
-                        for stdin in the container runtime. If this is not set, reads
-                        from stdin in the container will always result in EOF. Default
-                        is false.
                       type: boolean
                     stdinOnce:
-                      description: Whether the container runtime should close the
-                        stdin channel after it has been opened by a single attach.
-                        When stdin is true the stdin stream will remain open across
-                        multiple attach sessions. If stdinOnce is set to true, stdin
-                        is opened on container start, is empty until the first client
-                        attaches to stdin, and then remains open and accepts data
-                        until the client disconnects, at which time stdin is closed
-                        and remains closed until the container is restarted. If this
-                        flag is false, a container processes that reads from stdin
-                        will never receive an EOF. Default is false
                       type: boolean
                     tektonTask:
-                      description: TektonTask is for referring local Tasks or the
-                        Tasks registered in tekton catalog github repo.
                       properties:
                         params:
-                          description: Params are input params for the task
                           items:
-                            description: ParameterValue defines values of parameter
                             properties:
                               arrayVal:
                                 items:
@@ -1347,61 +719,29 @@ spec:
                             type: object
                           type: array
                         resources:
-                          description: Resources are input/output resources for the
-                            task
                           properties:
                             inputs:
-                              description: Inputs holds the inputs resources this
-                                task was invoked with
                               items:
-                                description: TaskResourceBinding points to the PipelineResource
-                                  that will be used for the Task input or output called
-                                  Name.
                                 properties:
                                   name:
-                                    description: Name is the name of the PipelineResource
-                                      in the Pipeline's declaration
                                     type: string
                                   paths:
-                                    description: 'Paths will probably be removed in
-                                      #1284, and then PipelineResourceBinding can
-                                      be used instead. The optional Path field corresponds
-                                      to a path on disk at which the Resource can
-                                      be found (used when providing the resource via
-                                      mounted volume, overriding the default logic
-                                      to fetch the Resource).'
                                     items:
                                       type: string
                                     type: array
                                   resourceRef:
-                                    description: ResourceRef is a reference to the
-                                      instance of the actual PipelineResource that
-                                      should be used
                                     properties:
                                       apiVersion:
-                                        description: API version of the referent
                                         type: string
                                       name:
-                                        description: 'Name of the referent; More info:
-                                          http://kubernetes.io/docs/user-guide/identifiers#names'
                                         type: string
                                     type: object
                                   resourceSpec:
-                                    description: ResourceSpec is specification of
-                                      a resource that should be created and consumed
-                                      by the task
                                     properties:
                                       description:
-                                        description: Description is a user-facing
-                                          description of the resource that may be
-                                          used to populate a UI.
                                         type: string
                                       params:
                                         items:
-                                          description: ResourceParam declares a string
-                                            value to use for the parameter called
-                                            Name, and is used in the specific context
-                                            of PipelineResources.
                                           properties:
                                             name:
                                               type: string
@@ -1413,12 +753,7 @@ spec:
                                           type: object
                                         type: array
                                       secrets:
-                                        description: Secrets to fetch to populate
-                                          some of resource fields
                                         items:
-                                          description: SecretParam indicates which
-                                            secret can be used to populate a field
-                                            of the resource
                                           properties:
                                             fieldName:
                                               type: string
@@ -1441,57 +776,27 @@ spec:
                                 type: object
                               type: array
                             outputs:
-                              description: Outputs holds the inputs resources this
-                                task was invoked with
                               items:
-                                description: TaskResourceBinding points to the PipelineResource
-                                  that will be used for the Task input or output called
-                                  Name.
                                 properties:
                                   name:
-                                    description: Name is the name of the PipelineResource
-                                      in the Pipeline's declaration
                                     type: string
                                   paths:
-                                    description: 'Paths will probably be removed in
-                                      #1284, and then PipelineResourceBinding can
-                                      be used instead. The optional Path field corresponds
-                                      to a path on disk at which the Resource can
-                                      be found (used when providing the resource via
-                                      mounted volume, overriding the default logic
-                                      to fetch the Resource).'
                                     items:
                                       type: string
                                     type: array
                                   resourceRef:
-                                    description: ResourceRef is a reference to the
-                                      instance of the actual PipelineResource that
-                                      should be used
                                     properties:
                                       apiVersion:
-                                        description: API version of the referent
                                         type: string
                                       name:
-                                        description: 'Name of the referent; More info:
-                                          http://kubernetes.io/docs/user-guide/identifiers#names'
                                         type: string
                                     type: object
                                   resourceSpec:
-                                    description: ResourceSpec is specification of
-                                      a resource that should be created and consumed
-                                      by the task
                                     properties:
                                       description:
-                                        description: Description is a user-facing
-                                          description of the resource that may be
-                                          used to populate a UI.
                                         type: string
                                       params:
                                         items:
-                                          description: ResourceParam declares a string
-                                            value to use for the parameter called
-                                            Name, and is used in the specific context
-                                            of PipelineResources.
                                           properties:
                                             name:
                                               type: string
@@ -1503,12 +808,7 @@ spec:
                                           type: object
                                         type: array
                                       secrets:
-                                        description: Secrets to fetch to populate
-                                          some of resource fields
                                         items:
-                                          description: SecretParam indicates which
-                                            secret can be used to populate a field
-                                            of the resource
                                           properties:
                                             fieldName:
                                               type: string
@@ -1532,50 +832,29 @@ spec:
                               type: array
                           type: object
                         taskRef:
-                          description: TaskRef refers to the existing Task in local
-                            cluster or to the tekton catalog github repo.
                           properties:
                             catalog:
-                              description: 'Catalog is a name of the task @ tekton
-                                catalog github repo. (e.g., s2i@0.2) FYI: https://github.com/tektoncd/catalog'
                               type: string
                             local:
-                              description: Local refers to local tasks/cluster tasks
                               properties:
                                 apiVersion:
-                                  description: API version of the referent
                                   type: string
                                 bundle:
-                                  description: Bundle url reference to a Tekton Bundle.
                                   type: string
                                 kind:
-                                  description: TaskKind indicates the kind of the
-                                    task, namespaced or cluster scoped.
                                   type: string
                                 name:
-                                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                   type: string
                               type: object
                           type: object
                         workspaces:
-                          description: Workspaces are workspaces for the task
                           items:
-                            description: WorkspacePipelineTaskBinding describes how
-                              a workspace passed into the pipeline should be mapped
-                              to a task's declared workspace.
                             properties:
                               name:
-                                description: Name is the name of the workspace as
-                                  declared by the task
                                 type: string
                               subPath:
-                                description: SubPath is optionally a directory on
-                                  the volume which should be used for this binding
-                                  (i.e. the volume will be mounted at this sub directory).
                                 type: string
                               workspace:
-                                description: Workspace is the name of the workspace
-                                  declared by the pipeline
                                 type: string
                             required:
                             - name
@@ -1586,24 +865,13 @@ spec:
                       - taskRef
                       type: object
                     tektonWhen:
-                      description: TektonWhen is for conditional execution. Input
-                        can be parameters or results
                       items:
-                        description: WhenExpression allows a PipelineTask to declare
-                          expressions to be evaluated before the Task is run to determine
-                          whether the Task should be executed or skipped
                         properties:
                           input:
-                            description: Input is the string for guard checking which
-                              can be a static input or an output from a parent Task
                             type: string
                           operator:
-                            description: Operator that represents an Input's relationship
-                              to the values
                             type: string
                           values:
-                            description: Values is an array of strings, which is compared
-                              against the input, for guard checking It must be non-empty
                             items:
                               type: string
                             type: array
@@ -1614,42 +882,17 @@ spec:
                         type: object
                       type: array
                     terminationMessagePath:
-                      description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                       type: string
                     terminationMessagePolicy:
-                      description: Indicate how the termination message should be
-                        populated. File will use the contents of terminationMessagePath
-                        to populate the container status message on both success and
-                        failure. FallbackToLogsOnError will use the last chunk of
-                        container log output if the termination message file is empty
-                        and the container exited with an error. The log output is
-                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                        to File. Cannot be updated.
                       type: string
                     tty:
-                      description: Whether this container should allocate a TTY for
-                        itself, also requires 'stdin' to be true. Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be
-                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block
-                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container
-                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim
-                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -1657,40 +900,19 @@ spec:
                         type: object
                       type: array
                     volumeMounts:
-                      description: Pod volumes to mount into the container's filesystem.
-                        Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
                         properties:
                           mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
                             type: string
                           name:
-                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -1698,7 +920,6 @@ spec:
                         type: object
                       type: array
                     when:
-                      description: When is condition for running the job
                       properties:
                         branch:
                           items:
@@ -1718,22 +939,15 @@ spec:
                           type: array
                       type: object
                     workingDir:
-                      description: Container's working directory. If not specified,
-                        the container runtime's default will be used, which might
-                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               paramConfig:
-                description: ParamConfig specifies parameter
                 properties:
                   paramDefine:
-                    description: ParamDefine is used to define parameter's spec
                     items:
-                      description: ParameterDefine defines a parameter's name, description
-                        & default values
                       properties:
                         defaultArray:
                           items:
@@ -1750,9 +964,7 @@ spec:
                       type: object
                     type: array
                   paramValue:
-                    description: ParamValue can specify values of parameters
                     items:
-                      description: ParameterValue defines values of parameter
                       properties:
                         arrayVal:
                           items:
@@ -1768,68 +980,24 @@ spec:
                     type: array
                 type: object
               podTemplate:
-                description: PodTemplate for the TaskRun pods. Same as tekton's pod
-                  template
                 properties:
                   affinity:
-                    description: If specified, the pod's scheduling constraints
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node matches the corresponding matchExpressions;
-                              the node(s) with the highest sum are the most preferred.
                             items:
-                              description: An empty preferred scheduling term matches
-                                all objects with implicit weight 0 (i.e. it's a no-op).
-                                A null preferred scheduling term matches no objects
-                                (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1839,35 +1007,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1878,8 +1024,6 @@ spec:
                                       type: array
                                   type: object
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -1888,53 +1032,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from
-                              its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
                                 items:
-                                  description: A null or empty node selector term
-                                    matches no objects. The requirements of them are
-                                    ANDed. The TopologySelectorTerm type implements
-                                    a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1944,35 +1053,13 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
                                       items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
                                             type: string
                                           operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
                                             type: string
                                           values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
                                             items:
                                               type: string
                                             type: array
@@ -1988,65 +1075,22 @@ spec:
                             type: object
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2058,54 +1102,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2117,41 +1125,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2160,56 +1145,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to a pod label update),
-                              the system may or may not try to eventually evict the
-                              pod from its node. When there are multiple elements,
-                              the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -2221,53 +1168,18 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -2279,32 +1191,13 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -2312,65 +1205,22 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the anti-affinity expressions
-                              specified by this field, but it may choose a node that
-                              violates one or more of the expressions. The node that
-                              is most preferred is the one with the greatest sum of
-                              weights, i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              anti-affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2382,54 +1232,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces
-                                        that the term applies to. The term is applied
-                                        to the union of the namespaces selected by
-                                        this field and the ones listed in the namespaces
-                                        field. null selector and null or empty namespaces
-                                        list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2441,41 +1255,18 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list
-                                        of namespace names that the term applies to.
-                                        The term is applied to the union of the namespaces
-                                        listed in this field and the ones selected
-                                        by namespaceSelector. null or empty namespaces
-                                        list and null namespaceSelector means "this
-                                        pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2484,56 +1275,18 @@ spec:
                               type: object
                             type: array
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified
-                              by this field are not met at scheduling time, the pod
-                              will not be scheduled onto the node. If the anti-affinity
-                              requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod
-                              label update), the system may or may not try to eventually
-                              evict the pod from its node. When there are multiple
-                              elements, the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
                             items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -2545,53 +1298,18 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -2603,32 +1321,13 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
@@ -2637,237 +1336,107 @@ spec:
                         type: object
                     type: object
                   automountServiceAccountToken:
-                    description: AutomountServiceAccountToken indicates whether pods
-                      running as this service account should have an API token automatically
-                      mounted.
                     type: boolean
                   dnsConfig:
-                    description: Specifies the DNS parameters of a pod. Parameters
-                      specified here will be merged to the generated DNS configuration
-                      based on DNSPolicy.
                     properties:
                       nameservers:
-                        description: A list of DNS name server IP addresses. This
-                          will be appended to the base nameservers generated from
-                          DNSPolicy. Duplicated nameservers will be removed.
                         items:
                           type: string
                         type: array
                       options:
-                        description: A list of DNS resolver options. This will be
-                          merged with the base options generated from DNSPolicy. Duplicated
-                          entries will be removed. Resolution options given in Options
-                          will override those that appear in the base DNSPolicy.
                         items:
-                          description: PodDNSConfigOption defines DNS resolver options
-                            of a pod.
                           properties:
                             name:
-                              description: Required.
                               type: string
                             value:
                               type: string
                           type: object
                         type: array
                       searches:
-                        description: A list of DNS search domains for host-name lookup.
-                          This will be appended to the base search paths generated
-                          from DNSPolicy. Duplicated search paths will be removed.
                         items:
                           type: string
                         type: array
                     type: object
                   dnsPolicy:
-                    description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                      Valid values are 'ClusterFirst', 'Default' or 'None'. DNS parameters
-                      given in DNSConfig will be merged with the policy selected with
-                      DNSPolicy.
                     type: string
                   enableServiceLinks:
-                    description: 'EnableServiceLinks indicates whether information
-                      about services should be injected into pod''s environment variables,
-                      matching the syntax of Docker links. Optional: Defaults to true.'
                     type: boolean
                   hostAliases:
-                    description: HostAliases is an optional list of hosts and IPs
-                      that will be injected into the pod's hosts file if specified.
-                      This is only valid for non-hostNetwork pods.
                     items:
-                      description: HostAlias holds the mapping between IP and hostnames
-                        that will be injected as an entry in the pod's hosts file.
                       properties:
                         hostnames:
-                          description: Hostnames for the above IP address.
                           items:
                             type: string
                           type: array
                         ip:
-                          description: IP address of the host file entry.
                           type: string
                       type: object
                     type: array
                   hostNetwork:
-                    description: HostNetwork specifies whether the pod may use the
-                      node network namespace
                     type: boolean
                   imagePullSecrets:
-                    description: ImagePullSecrets gives the name of the secret used
-                      by the pod to pull the image if specified
                     items:
-                      description: LocalObjectReference contains enough information
-                        to let you locate the referenced object inside the same namespace.
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: 'NodeSelector is a selector which must be true for
-                      the pod to fit on a node. Selector which must match a node''s
-                      labels for the pod to be scheduled on that node. More info:
-                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                     type: object
                   priorityClassName:
-                    description: If specified, indicates the pod's priority. "system-node-critical"
-                      and "system-cluster-critical" are two special keywords which
-                      indicate the highest priorities with the former being the highest
-                      priority. Any other name must be defined by creating a PriorityClass
-                      object with that name. If not specified, the pod priority will
-                      be default or zero if there is no default.
                     type: string
                   runtimeClassName:
-                    description: 'RuntimeClassName refers to a RuntimeClass object
-                      in the node.k8s.io group, which should be used to run this pod.
-                      If no RuntimeClass resource matches the named class, the pod
-                      will not be run. If unset or empty, the "legacy" RuntimeClass
-                      will be used, which is an implicit class with an empty definition
-                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                      This is a beta feature as of Kubernetes v1.14.'
                     type: string
                   schedulerName:
-                    description: SchedulerName specifies the scheduler to be used
-                      to dispatch the Pod
                     type: string
                   securityContext:
-                    description: 'SecurityContext holds pod-level security attributes
-                      and common container settings. Optional: Defaults to empty.  See
-                      type description for default values of each field.'
                     properties:
                       fsGroup:
-                        description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
                         format: int64
                         type: integer
                       fsGroupChangePolicy:
-                        description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
                         type: string
                       runAsGroup:
-                        description: The GID to run the entrypoint of the container
-                          process. Uses runtime default if unset. May also be set
-                          in SecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence for that container.
                         format: int64
                         type: integer
                       runAsNonRoot:
-                        description: Indicates that the container must run as a non-root
-                          user. If true, the Kubelet will validate the image at runtime
-                          to ensure that it does not run as UID 0 (root) and fail
-                          to start the container if it does. If unset or false, no
-                          such validation will be performed. May also be set in SecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
                         type: boolean
                       runAsUser:
-                        description: The UID to run the entrypoint of the container
-                          process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in SecurityContext.  If set
-                          in both SecurityContext and PodSecurityContext, the value
-                          specified in SecurityContext takes precedence for that container.
                         format: int64
                         type: integer
                       seLinuxOptions:
-                        description: The SELinux context to be applied to all containers.
-                          If unspecified, the container runtime will allocate a random
-                          SELinux context for each container.  May also be set in
-                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                          the value specified in SecurityContext takes precedence
-                          for that container.
                         properties:
                           level:
-                            description: Level is SELinux level label that applies
-                              to the container.
                             type: string
                           role:
-                            description: Role is a SELinux role label that applies
-                              to the container.
                             type: string
                           type:
-                            description: Type is a SELinux type label that applies
-                              to the container.
                             type: string
                           user:
-                            description: User is a SELinux user label that applies
-                              to the container.
                             type: string
                         type: object
                       seccompProfile:
-                        description: The seccomp options to use by the containers
-                          in this pod.
                         properties:
                           localhostProfile:
-                            description: localhostProfile indicates a profile defined
-                              in a file on the node should be used. The profile must
-                              be preconfigured on the node to work. Must be a descending
-                              path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
                             type: string
                           type:
-                            description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                             type: string
                         required:
                         - type
                         type: object
                       supplementalGroups:
-                        description: A list of groups applied to the first process
-                          run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
                         items:
                           format: int64
                           type: integer
                         type: array
                       sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used
-                          for the pod. Pods with unsupported sysctls (by the container
-                          runtime) might fail to launch.
                         items:
-                          description: Sysctl defines a kernel parameter to be set
                           properties:
                             name:
-                              description: Name of a property to set
                               type: string
                             value:
-                              description: Value of a property to set
                               type: string
                           required:
                           - name
@@ -2875,307 +1444,132 @@ spec:
                           type: object
                         type: array
                       windowsOptions:
-                        description: The Windows specific settings applied to all
-                          containers. If unspecified, the options within a container's
-                          SecurityContext will be used. If set in both SecurityContext
-                          and PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
                         properties:
                           gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field.
                             type: string
                           gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use.
                             type: string
                           hostProcess:
-                            description: HostProcess determines if a container should
-                              be run as a 'Host Process' container. This field is
-                              alpha-level and will only be honored by components that
-                              enable the WindowsHostProcessContainers feature flag.
-                              Setting this field without the feature flag will result
-                              in errors when validating the Pod. All of a Pod's containers
-                              must have the same effective HostProcess value (it is
-                              not allowed to have a mix of HostProcess containers
-                              and non-HostProcess containers).  In addition, if HostProcess
-                              is true then HostNetwork must also be set to true.
                             type: boolean
                           runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
                             type: string
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   volumes:
-                    description: 'List of volumes that can be mounted by containers
-                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                     items:
-                      description: Volume represents a named volume in a pod that
-                        may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
-                          description: 'AWSElasticBlockStore represents an AWS Disk
-                            resource that is attached to a kubelet''s host machine
-                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty).'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Specify "true" to force and set the ReadOnly
-                                property in VolumeMounts to "true". If omitted, the
-                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: boolean
                             volumeID:
-                              description: 'Unique ID of the persistent disk resource
-                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: AzureDisk represents an Azure Data Disk mount
-                            on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'Host Caching mode: None, Read Only, Read
-                                Write.'
                               type: string
                             diskName:
-                              description: The Name of the data disk in the blob storage
                               type: string
                             diskURI:
-                              description: The URI the data disk in the blob storage
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             kind:
-                              description: 'Expected values Shared: multiple blob
-                                disks per storage account  Dedicated: single blob
-                                disk per storage account  Managed: azure managed data
-                                disk (only in managed availability set). defaults
-                                to shared'
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
-                          description: AzureFile represents an Azure File Service
-                            mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: the name of secret that contains Azure
-                                Storage Account Name and Key
                               type: string
                             shareName:
-                              description: Share Name
                               type: string
                           required:
                           - secretName
                           - shareName
                           type: object
                         cephfs:
-                          description: CephFS represents a Ceph FS mount on the host
-                            that shares a pod's lifetime
                           properties:
                             monitors:
-                              description: 'Required: Monitors is a collection of
-                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             path:
-                              description: 'Optional: Used as the mounted root, rather
-                                than the full Ceph tree, default is /'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: boolean
                             secretFile:
-                              description: 'Optional: SecretFile is the path to key
-                                ring for User, default is /etc/ceph/user.secret More
-                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                authentication secret for User, default is empty.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             user:
-                              description: 'Optional: User is the rados user name,
-                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
-                          description: 'Cinder represents a cinder volume attached
-                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: boolean
                             secretRef:
-                              description: 'Optional: points to a secret object containing
-                                parameters used to connect to OpenStack.'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             volumeID:
-                              description: 'volume id used to identify the volume
-                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
-                          description: ConfigMap represents a configMap that should
-                            populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced ConfigMap will be
-                                projected into the volume as a file whose name is
-                                the key and content is the value. If specified, the
-                                listed keys will be projected into the specified paths,
-                                and unlisted keys will not be present. If a key is
-                                specified which is not present in the ConfigMap, the
-                                volume setup will error unless it is marked optional.
-                                Paths must be relative and may not contain the '..'
-                                path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a
-                                  volume.
                                 properties:
                                   key:
-                                    description: The key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -3183,140 +1577,63 @@ spec:
                                 type: object
                               type: array
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its keys
-                                must be defined
                               type: boolean
                           type: object
                         csi:
-                          description: CSI (Container Storage Interface) represents
-                            ephemeral storage that is handled by certain external
-                            CSI drivers (Beta feature).
                           properties:
                             driver:
-                              description: Driver is the name of the CSI driver that
-                                handles this volume. Consult with your admin for the
-                                correct name as registered in the cluster.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Ex. "ext4", "xfs",
-                                "ntfs". If not provided, the empty value is passed
-                                to the associated CSI driver which will determine
-                                the default filesystem to apply.
                               type: string
                             nodePublishSecretRef:
-                              description: NodePublishSecretRef is a reference to
-                                the secret object containing sensitive information
-                                to pass to the CSI driver to complete the CSI NodePublishVolume
-                                and NodeUnpublishVolume calls. This field is optional,
-                                and  may be empty if no secret is required. If the
-                                secret object contains more than one secret, all secret
-                                references are passed.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             readOnly:
-                              description: Specifies a read-only configuration for
-                                the volume. Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
-                              description: VolumeAttributes stores driver-specific
-                                properties that are passed to the CSI driver. Consult
-                                your driver's documentation for supported values.
                               type: object
                           required:
                           - driver
                           type: object
                         downwardAPI:
-                          description: DownwardAPI represents downward API about the
-                            pod that should populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits to use on created
-                                files by default. Must be a Optional: mode bits used
-                                to set permissions on created files by default. Must
-                                be an octal value between 0000 and 0777 or a decimal
-                                value between 0 and 511. YAML accepts both octal and
-                                decimal values, JSON requires decimal values for mode
-                                bits. Defaults to 0644. Directories within the path
-                                are not affected by this setting. This might be in
-                                conflict with other options that affect the file mode,
-                                like fsGroup, and the result can be other mode bits
-                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: Items is a list of downward API volume
-                                file
                               items:
-                                description: DownwardAPIVolumeFile represents information
-                                  to create the file containing the pod field
                                 properties:
                                   fieldRef:
-                                    description: 'Required: Selects a field of the
-                                      pod: only annotations, labels, name and namespace
-                                      are supported.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file, must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: 'Required: Path is  the relative
-                                      path name of the file to be created. Must not
-                                      be absolute or contain the ''..'' path. Must
-                                      be utf-8 encoded. The first item of the relative
-                                      path must not start with ''..'''
                                     type: string
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, requests.cpu and requests.memory)
-                                      are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
-                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
@@ -3327,176 +1644,53 @@ spec:
                               type: array
                           type: object
                         emptyDir:
-                          description: 'EmptyDir represents a temporary directory
-                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           properties:
                             medium:
-                              description: 'What type of storage medium should back
-                                this directory. The default is "" which means to use
-                                the node''s default medium. Must be an empty string
-                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Total amount of local storage required
-                                for this EmptyDir volume. The size limit is also applicable
-                                for memory medium. The maximum usage on memory medium
-                                EmptyDir would be the minimum value between the SizeLimit
-                                specified here and the sum of memory limits of all
-                                containers in a pod. The default is nil which means
-                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
-                          description: "Ephemeral represents a volume that is handled
-                            by a cluster storage driver. The volume's lifecycle is
-                            tied to the pod that defines it - it will be created before
-                            the pod starts, and deleted when the pod is removed. \n
-                            Use this if: a) the volume is only needed while the pod
-                            runs, b) features of normal volumes like restoring from
-                            snapshot or capacity    tracking are needed, c) the storage
-                            driver is specified through a storage class, and d) the
-                            storage driver supports dynamic volume provisioning through
-                            \   a PersistentVolumeClaim (see EphemeralVolumeSource
-                            for more    information on the connection between this
-                            volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                            or one of the vendor-specific APIs for volumes that persist
-                            for longer than the lifecycle of an individual pod. \n
-                            Use CSI for light-weight local ephemeral volumes if the
-                            CSI driver is meant to be used that way - see the documentation
-                            of the driver for more information. \n A pod can use both
-                            types of ephemeral volumes and persistent volumes at the
-                            same time. \n This is a beta feature and only available
-                            when the GenericEphemeralVolume feature gate is enabled."
                           properties:
                             volumeClaimTemplate:
-                              description: "Will be used to create a stand-alone PVC
-                                to provision the volume. The pod in which this EphemeralVolumeSource
-                                is embedded will be the owner of the PVC, i.e. the
-                                PVC will be deleted together with the pod.  The name
-                                of the PVC will be `<pod name>-<volume name>` where
-                                `<volume name>` is the name from the `PodSpec.Volumes`
-                                array entry. Pod validation will reject the pod if
-                                the concatenated name is not valid for a PVC (for
-                                example, too long). \n An existing PVC with that name
-                                that is not owned by the pod will *not* be used for
-                                the pod to avoid using an unrelated volume by mistake.
-                                Starting the pod is then blocked until the unrelated
-                                PVC is removed. If such a pre-created PVC is meant
-                                to be used by the pod, the PVC has to updated with
-                                an owner reference to the pod once the pod exists.
-                                Normally this should not be necessary, but it may
-                                be useful when manually reconstructing a broken cluster.
-                                \n This field is read-only and no changes will be
-                                made by Kubernetes to the PVC after it has been created.
-                                \n Required, must not be nil."
                               properties:
                                 metadata:
-                                  description: May contain labels and annotations
-                                    that will be copied into the PVC when creating
-                                    it. No other fields are allowed and will be rejected
-                                    during validation.
                                   type: object
                                 spec:
-                                  description: The specification for the PersistentVolumeClaim.
-                                    The entire content is copied unchanged into the
-                                    PVC that gets created from this template. The
-                                    same fields as in a PersistentVolumeClaim are
-                                    also valid here.
                                   properties:
                                     accessModes:
-                                      description: 'AccessModes contains the desired
-                                        access modes the volume should have. More
-                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'This field can be used to specify
-                                        either: * An existing VolumeSnapshot object
-                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
-                                        An existing PVC (PersistentVolumeClaim) If
-                                        the provisioner or an external controller
-                                        can support the specified data source, it
-                                        will create a new volume based on the contents
-                                        of the specified data source. If the AnyVolumeDataSource
-                                        feature gate is enabled, this field will always
-                                        have the same contents as the DataSourceRef
-                                        field.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the
-                                            resource being referenced. If APIGroup
-                                            is not specified, the specified Kind must
-                                            be in the core API group. For any other
-                                            third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource
-                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource
-                                            being referenced
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     dataSourceRef:
-                                      description: 'Specifies the object from which
-                                        to populate the volume with data, if a non-empty
-                                        volume is desired. This may be any local object
-                                        from a non-empty API group (non core object)
-                                        or a PersistentVolumeClaim object. When this
-                                        field is specified, volume binding will only
-                                        succeed if the type of the specified object
-                                        matches some installed volume populator or
-                                        dynamic provisioner. This field will replace
-                                        the functionality of the DataSource field
-                                        and as such if both fields are non-empty,
-                                        they must have the same value. For backwards
-                                        compatibility, both fields (DataSource and
-                                        DataSourceRef) will be set to the same value
-                                        automatically if one of them is empty and
-                                        the other is non-empty. There are two important
-                                        differences between DataSource and DataSourceRef:
-                                        * While DataSource only allows two specific
-                                        types of objects, DataSourceRef   allows any
-                                        non-core object, as well as PersistentVolumeClaim
-                                        objects. * While DataSource ignores disallowed
-                                        values (dropping them), DataSourceRef   preserves
-                                        all values, and generates an error if a disallowed
-                                        value is   specified. (Alpha) Using this field
-                                        requires the AnyVolumeDataSource feature gate
-                                        to be enabled.'
                                       properties:
                                         apiGroup:
-                                          description: APIGroup is the group for the
-                                            resource being referenced. If APIGroup
-                                            is not specified, the specified Kind must
-                                            be in the core API group. For any other
-                                            third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource
-                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource
-                                            being referenced
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
-                                      description: 'Resources represents the minimum
-                                        resources the volume should have. More info:
-                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -3505,9 +1699,6 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3516,47 +1707,18 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           type: object
                                       type: object
                                     selector:
-                                      description: A label query over volumes to consider
-                                        for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3568,27 +1730,13 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     storageClassName:
-                                      description: 'Name of the StorageClass required
-                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                       type: string
                                     volumeMode:
-                                      description: volumeMode defines what type of
-                                        volume is required by the claim. Value of
-                                        Filesystem is implied when not included in
-                                        claim spec.
                                       type: string
                                     volumeName:
-                                      description: VolumeName is the binding reference
-                                        to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -3596,257 +1744,125 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: FC represents a Fibre Channel resource that
-                            is attached to a kubelet's host machine and then exposed
-                            to the pod.
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified. TODO: how do we prevent errors in the
-                                filesystem from compromising the machine'
                               type: string
                             lun:
-                              description: 'Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                               type: boolean
                             targetWWNs:
-                              description: 'Optional: FC target worldwide names (WWNs)'
                               items:
                                 type: string
                               type: array
                             wwids:
-                              description: 'Optional: FC volume world wide identifiers
-                                (wwids) Either wwids or combination of targetWWNs
-                                and lun must be set, but not both simultaneously.'
                               items:
                                 type: string
                               type: array
                           type: object
                         flexVolume:
-                          description: FlexVolume represents a generic volume resource
-                            that is provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: Driver is the name of the driver to use
-                                for this volume.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". The default filesystem depends on FlexVolume
-                                script.
                               type: string
                             options:
                               additionalProperties:
                                 type: string
-                              description: 'Optional: Extra command options if any.'
                               type: object
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                               type: boolean
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                secret object containing sensitive information to
-                                pass to the plugin scripts. This may be empty if no
-                                secret object is specified. If the secret object contains
-                                more than one secret, all secrets are passed to the
-                                plugin scripts.'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                           required:
                           - driver
                           type: object
                         flocker:
-                          description: Flocker represents a Flocker volume attached
-                            to a kubelet's host machine. This depends on the Flocker
-                            control service being running
                           properties:
                             datasetName:
-                              description: Name of the dataset stored as metadata
-                                -> name on the dataset for Flocker should be considered
-                                as deprecated
                               type: string
                             datasetUUID:
-                              description: UUID of the dataset. This is unique identifier
-                                of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
-                          description: 'GCEPersistentDisk represents a GCE Disk resource
-                            that is attached to a kubelet''s host machine and then
-                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               format: int32
                               type: integer
                             pdName:
-                              description: 'Unique name of the PD resource in GCE.
-                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
-                                setting in VolumeMounts. Defaults to false. More info:
-                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: boolean
                           required:
                           - pdName
                           type: object
                         gitRepo:
-                          description: 'GitRepo represents a git repository at a particular
-                            revision. DEPRECATED: GitRepo is deprecated. To provision
-                            a container with a git repo, mount an EmptyDir into an
-                            InitContainer that clones the repo using git, then mount
-                            the EmptyDir into the Pod''s container.'
                           properties:
                             directory:
-                              description: Target directory name. Must not contain
-                                or start with '..'.  If '.' is supplied, the volume
-                                directory will be the git repository.  Otherwise,
-                                if specified, the volume will contain the git repository
-                                in the subdirectory with the given name.
                               type: string
                             repository:
-                              description: Repository URL
                               type: string
                             revision:
-                              description: Commit hash for the specified revision.
                               type: string
                           required:
                           - repository
                           type: object
                         glusterfs:
-                          description: 'Glusterfs represents a Glusterfs mount on
-                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                           properties:
                             endpoints:
-                              description: 'EndpointsName is the endpoint name that
-                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             path:
-                              description: 'Path is the Glusterfs volume path. More
-                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the Glusterfs
-                                volume to be mounted with read-only permissions. Defaults
-                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: boolean
                           required:
                           - endpoints
                           - path
                           type: object
                         hostPath:
-                          description: 'HostPath represents a pre-existing file or
-                            directory on the host machine that is directly exposed
-                            to the container. This is generally used for system agents
-                            or other privileged things that are allowed to see the
-                            host machine. Most containers will NOT need this. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                            --- TODO(jonesdl) We need to restrict who can use host
-                            directory mounts and who can/can not mount host directories
-                            as read/write.'
                           properties:
                             path:
-                              description: 'Path of the directory on the host. If
-                                the path is a symlink, it will follow the link to
-                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                             type:
-                              description: 'Type for HostPath Volume Defaults to ""
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
-                          description: 'ISCSI represents an ISCSI Disk resource that
-                            is attached to a kubelet''s host machine and then exposed
-                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                           properties:
                             chapAuthDiscovery:
-                              description: whether support iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
-                              description: whether support iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             initiatorName:
-                              description: Custom iSCSI Initiator Name. If initiatorName
-                                is specified with iscsiInterface simultaneously, new
-                                iSCSI interface <target portal>:<volume name> will
-                                be created for the connection.
                               type: string
                             iqn:
-                              description: Target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
-                              description: iSCSI Interface Name that uses an iSCSI
-                                transport. Defaults to 'default' (tcp).
                               type: string
                             lun:
-                              description: iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
-                              description: iSCSI Target Portal List. The portal is
-                                either an IP or ip_addr:port if the port is other
-                                than default (typically TCP ports 860 and 3260).
                               items:
                                 type: string
                               type: array
                             readOnly:
-                              description: ReadOnly here will force the ReadOnly setting
-                                in VolumeMounts. Defaults to false.
                               type: boolean
                             secretRef:
-                              description: CHAP Secret for iSCSI target and initiator
-                                authentication
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             targetPortal:
-                              description: iSCSI Target Portal. The Portal is either
-                                an IP or ip_addr:port if the port is other than default
-                                (typically TCP ports 860 and 3260).
                               type: string
                           required:
                           - iqn
@@ -3854,153 +1870,67 @@ spec:
                           - targetPortal
                           type: object
                         name:
-                          description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         nfs:
-                          description: 'NFS represents an NFS mount on the host that
-                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           properties:
                             path:
-                              description: 'Path that is exported by the NFS server.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the NFS export
-                                to be mounted with read-only permissions. Defaults
-                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: boolean
                             server:
-                              description: 'Server is the hostname or IP address of
-                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                           required:
                           - path
                           - server
                           type: object
                         persistentVolumeClaim:
-                          description: 'PersistentVolumeClaimVolumeSource represents
-                            a reference to a PersistentVolumeClaim in the same namespace.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             claimName:
-                              description: 'ClaimName is the name of a PersistentVolumeClaim
-                                in the same namespace as the pod using this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               type: string
                             readOnly:
-                              description: Will force the ReadOnly setting in VolumeMounts.
-                                Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: PhotonPersistentDisk represents a PhotonController
-                            persistent disk attached and mounted on kubelets host
-                            machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             pdID:
-                              description: ID that identifies Photon Controller persistent
-                                disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: PortworxVolume represents a portworx volume
-                            attached and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: FSType represents the filesystem type to
-                                mount Must be a filesystem type supported by the host
-                                operating system. Ex. "ext4", "xfs". Implicitly inferred
-                                to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: VolumeID uniquely identifies a Portworx
-                                volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: Items for all in one resources secrets, configmaps,
-                            and downward API
                           properties:
                             defaultMode:
-                              description: Mode bits used to set permissions on created
-                                files by default. Must be an octal value between 0000
-                                and 0777 or a decimal value between 0 and 511. YAML
-                                accepts both octal and decimal values, JSON requires
-                                decimal values for mode bits. Directories within the
-                                path are not affected by this setting. This might
-                                be in conflict with other options that affect the
-                                file mode, like fsGroup, and the result can be other
-                                mode bits set.
                               format: int32
                               type: integer
                             sources:
-                              description: list of volume projections
                               items:
-                                description: Projection that may be projected along
-                                  with other supported volume types
                                 properties:
                                   configMap:
-                                    description: information about the configMap data
-                                      to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path
-                                            within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -4008,92 +1938,40 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
                                         type: boolean
                                     type: object
                                   downwardAPI:
-                                    description: information about the downwardAPI
-                                      data to project
                                     properties:
                                       items:
-                                        description: Items is a list of DownwardAPIVolume
-                                          file
                                         items:
-                                          description: DownwardAPIVolumeFile represents
-                                            information to create the file containing
-                                            the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field
-                                                of the pod: only annotations, labels,
-                                                name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema
-                                                    the FieldPath is written in terms
-                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to
-                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the
-                                                relative path name of the file to
-                                                be created. Must not be absolute or
-                                                contain the ''..'' path. Must be utf-8
-                                                encoded. The first item of the relative
-                                                path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required
-                                                    for volumes, optional for env
-                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output
-                                                    format of the exposed resources,
-                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource
-                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -4104,50 +1982,16 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: information about the secret data
-                                      to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path
-                                            within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -4155,45 +1999,18 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
                                         type: boolean
                                     type: object
                                   serviceAccountToken:
-                                    description: information about the serviceAccountToken
-                                      data to project
                                     properties:
                                       audience:
-                                        description: Audience is the intended audience
-                                          of the token. A recipient of a token must
-                                          identify itself with an identifier specified
-                                          in the audience of the token, and otherwise
-                                          should reject the token. The audience defaults
-                                          to the identifier of the apiserver.
                                         type: string
                                       expirationSeconds:
-                                        description: ExpirationSeconds is the requested
-                                          duration of validity of the service account
-                                          token. As the token approaches expiration,
-                                          the kubelet volume plugin will proactively
-                                          rotate the service account token. The kubelet
-                                          will start trying to rotate the token if
-                                          the token is older than 80 percent of its
-                                          time to live or if the token is older than
-                                          24 hours.Defaults to 1 hour and must be
-                                          at least 10 minutes.
                                         format: int64
                                         type: integer
                                       path:
-                                        description: Path is the path relative to
-                                          the mount point of the file to project the
-                                          token into.
                                         type: string
                                     required:
                                     - path
@@ -4202,148 +2019,74 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: Quobyte represents a Quobyte mount on the host
-                            that shares a pod's lifetime
                           properties:
                             group:
-                              description: Group to map volume access to Default is
-                                no group
                               type: string
                             readOnly:
-                              description: ReadOnly here will force the Quobyte volume
-                                to be mounted with read-only permissions. Defaults
-                                to false.
                               type: boolean
                             registry:
-                              description: Registry represents a single or multiple
-                                Quobyte Registry services specified as a string as
-                                host:port pair (multiple entries are separated with
-                                commas) which acts as the central registry for volumes
                               type: string
                             tenant:
-                              description: Tenant owning the given Quobyte volume
-                                in the Backend Used with dynamically provisioned Quobyte
-                                volumes, value is set by the plugin
                               type: string
                             user:
-                              description: User to map volume access to Defaults to
-                                serivceaccount user
                               type: string
                             volume:
-                              description: Volume is a string that references an already
-                                created Quobyte volume by name.
                               type: string
                           required:
                           - registry
                           - volume
                           type: object
                         rbd:
-                          description: 'RBD represents a Rados Block Device mount
-                            on the host that shares a pod''s lifetime. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                TODO: how do we prevent errors in the filesystem from
-                                compromising the machine'
                               type: string
                             image:
-                              description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             keyring:
-                              description: 'Keyring is the path to key ring for RBDUser.
-                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             monitors:
-                              description: 'A collection of Ceph monitors. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             pool:
-                              description: 'The rados pool name. Default is rbd. More
-                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
-                                setting in VolumeMounts. Defaults to false. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: boolean
                             secretRef:
-                              description: 'SecretRef is name of the authentication
-                                secret for RBDUser. If provided overrides keyring.
-                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             user:
-                              description: 'The rados user name. Default is admin.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
-                          description: ScaleIO represents a ScaleIO persistent volume
-                            attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Default is "xfs".
                               type: string
                             gateway:
-                              description: The host address of the ScaleIO API Gateway.
                               type: string
                             protectionDomain:
-                              description: The name of the ScaleIO Protection Domain
-                                for the configured storage.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef references to the secret for
-                                ScaleIO user and other sensitive information. If this
-                                is not provided, Login operation will fail.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             sslEnabled:
-                              description: Flag to enable/disable SSL communication
-                                with Gateway, default false
                               type: boolean
                             storageMode:
-                              description: Indicates whether the storage for a volume
-                                should be ThickProvisioned or ThinProvisioned. Default
-                                is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: The ScaleIO Storage Pool associated with
-                                the protection domain.
                               type: string
                             system:
-                              description: The name of the storage system as configured
-                                in ScaleIO.
                               type: string
                             volumeName:
-                              description: The name of a volume already created in
-                                the ScaleIO system that is associated with this volume
-                                source.
                               type: string
                           required:
                           - gateway
@@ -4351,57 +2094,19 @@ spec:
                           - system
                           type: object
                         secret:
-                          description: 'Secret represents a secret that should populate
-                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be
-                                relative and may not contain the '..' path or start
-                                with '..'.
                               items:
-                                description: Maps a string key to a path within a
-                                  volume.
                                 properties:
                                   key:
-                                    description: The key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -4409,76 +2114,35 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: Specify whether the Secret or its keys
-                                must be defined
                               type: boolean
                             secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
                         storageos:
-                          description: StorageOS represents a StorageOS volume attached
-                            and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef specifies the secret to use for
-                                obtaining the StorageOS API credentials.  If not specified,
-                                default values will be attempted.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                               type: object
                             volumeName:
-                              description: VolumeName is the human-readable name of
-                                the StorageOS volume.  Volume names are only unique
-                                within a namespace.
                               type: string
                             volumeNamespace:
-                              description: VolumeNamespace specifies the scope of
-                                the volume within StorageOS.  If no namespace is specified
-                                then the Pod's namespace will be used.  This allows
-                                the Kubernetes name scoping to be mirrored within
-                                StorageOS for tighter integration. Set VolumeName
-                                to any name to override the default behaviour. Set
-                                to "default" if you are not using namespaces within
-                                StorageOS. Namespaces that do not pre-exist within
-                                StorageOS will be created.
                               type: string
                           type: object
                         vsphereVolume:
-                          description: VsphereVolume represents a vSphere volume attached
-                            and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
                               type: string
                             storagePolicyID:
-                              description: Storage Policy Based Management (SPBM)
-                                profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: Storage Policy Based Management (SPBM)
-                                profile name.
                               type: string
                             volumePath:
-                              description: Path that identifies vSphere volume vmdk
                               type: string
                           required:
                           - volumePath
@@ -4489,17 +2153,12 @@ spec:
                     type: array
                 type: object
               refs:
-                description: Refs
                 properties:
                   base:
-                    description: Base is a base pointer for base commit for the pull
-                      request If Pull is nil (i.e., is push event), Base works as
-                      Head
                     properties:
                       link:
                         type: string
                       ref:
-                        description: GitRef is a git reference type
                         type: string
                       sha:
                         type: string
@@ -4509,16 +2168,11 @@ spec:
                     - sha
                     type: object
                   link:
-                    description: Link is a full url of the repository
                     type: string
                   pulls:
-                    description: Pulls are array for pull request head commit
                     items:
-                      description: IntegrationJobRefsPull refers to the pull request
                       properties:
                         author:
-                          description: IntegrationJobRefsPullAuthor is an author of
-                            the pull request
                           properties:
                             name:
                               type: string
@@ -4530,7 +2184,6 @@ spec:
                         link:
                           type: string
                         ref:
-                          description: GitRef is a git reference type
                           type: string
                         sha:
                           type: string
@@ -4543,12 +2196,9 @@ spec:
                       type: object
                     type: array
                   repository:
-                    description: Repository name of git repository (in <org>/<repo>
-                      form, e.g., tmax-cloud/cicd-operator)
                     pattern: .+/.+
                     type: string
                   sender:
-                    description: Sender is a git user who triggered the webhook
                     properties:
                       email:
                         type: string
@@ -4564,63 +2214,24 @@ spec:
                 - sender
                 type: object
               timeout:
-                description: Timeout for pending status garbage collection
                 type: string
               workspaces:
-                description: Workspaces list
                 items:
-                  description: WorkspaceBinding maps a Task's declared workspace to
-                    a Volume.
                   properties:
                     configMap:
-                      description: ConfigMap represents a configMap that should populate
-                        this workspace.
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -4628,109 +2239,46 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the ConfigMap or its keys must
-                            be defined
                           type: boolean
                       type: object
                     emptyDir:
-                      description: 'EmptyDir represents a temporary directory that
-                        shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
-                        Either this OR PersistentVolumeClaim can be used.'
                       properties:
                         medium:
-                          description: 'What type of storage medium should back this
-                            directory. The default is "" which means to use the node''s
-                            default medium. Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'Total amount of local storage required for
-                            this EmptyDir volume. The size limit is also applicable
-                            for memory medium. The maximum usage on memory medium
-                            EmptyDir would be the minimum value between the SizeLimit
-                            specified here and the sum of memory limits of all containers
-                            in a pod. The default is nil which means that the limit
-                            is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     name:
-                      description: Name is the name of the workspace populated by
-                        the volume.
                       type: string
                     persistentVolumeClaim:
-                      description: PersistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        Either this OR EmptyDir can be used.
                       properties:
                         claimName:
-                          description: 'ClaimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
-                          description: Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     secret:
-                      description: Secret represents a secret that should populate
-                        this workspace.
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Defaults to 0644. Directories within
-                            the path are not affected by this setting. This might
-                            be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits
-                            set.'
                           format: int32
                           type: integer
                         items:
-                          description: If unspecified, each key-value pair in the
-                            Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: The key to project.
                                 type: string
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file. Must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: The relative path of the file to map
-                                  the key to. May not be an absolute path. May not
-                                  contain the path element '..'. May not start with
-                                  the string '..'.
                                 type: string
                             required:
                             - key
@@ -4738,124 +2286,51 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: Specify whether the Secret or its keys must
-                            be defined
                           type: boolean
                         secretName:
-                          description: 'Name of the secret in the pod''s namespace
-                            to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     subPath:
-                      description: SubPath is optionally a directory on the volume
-                        which should be used for this binding (i.e. the volume will
-                        be mounted at this sub directory).
                       type: string
                     volumeClaimTemplate:
-                      description: VolumeClaimTemplate is a template for a claim that
-                        will be created in the same namespace. The PipelineRun controller
-                        is responsible for creating a unique claim for each instance
-                        of PipelineRun.
                       properties:
                         apiVersion:
-                          description: 'APIVersion defines the versioned schema of
-                            this representation of an object. Servers should convert
-                            recognized schemas to the latest internal value, and may
-                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                           type: string
                         kind:
-                          description: 'Kind is a string value representing the REST
-                            resource this object represents. Servers may infer this
-                            from the endpoint the client submits requests to. Cannot
-                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                           type: string
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Spec defines the desired characteristics of
-                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             accessModes:
-                              description: 'AccessModes contains the desired access
-                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'This field can be used to specify either:
-                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                * An existing PVC (PersistentVolumeClaim) If the provisioner
-                                or an external controller can support the specified
-                                data source, it will create a new volume based on
-                                the contents of the specified data source. If the
-                                AnyVolumeDataSource feature gate is enabled, this
-                                field will always have the same contents as the DataSourceRef
-                                field.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being
-                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being
-                                    referenced
                                   type: string
                               required:
                               - kind
                               - name
                               type: object
                             dataSourceRef:
-                              description: 'Specifies the object from which to populate
-                                the volume with data, if a non-empty volume is desired.
-                                This may be any local object from a non-empty API
-                                group (non core object) or a PersistentVolumeClaim
-                                object. When this field is specified, volume binding
-                                will only succeed if the type of the specified object
-                                matches some installed volume populator or dynamic
-                                provisioner. This field will replace the functionality
-                                of the DataSource field and as such if both fields
-                                are non-empty, they must have the same value. For
-                                backwards compatibility, both fields (DataSource and
-                                DataSourceRef) will be set to the same value automatically
-                                if one of them is empty and the other is non-empty.
-                                There are two important differences between DataSource
-                                and DataSourceRef: * While DataSource only allows
-                                two specific types of objects, DataSourceRef   allows
-                                any non-core object, as well as PersistentVolumeClaim
-                                objects. * While DataSource ignores disallowed values
-                                (dropping them), DataSourceRef   preserves all values,
-                                and generates an error if a disallowed value is   specified.
-                                (Alpha) Using this field requires the AnyVolumeDataSource
-                                feature gate to be enabled.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being
-                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being
-                                    referenced
                                   type: string
                               required:
                               - kind
                               - name
                               type: object
                             resources:
-                              description: 'Resources represents the minimum resources
-                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -4864,8 +2339,6 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -4874,41 +2347,18 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                   type: object
                               type: object
                             selector:
-                              description: A label query over volumes to consider
-                                for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -4920,35 +2370,18 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
                                   type: object
                               type: object
                             storageClassName:
-                              description: 'Name of the StorageClass required by the
-                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume
-                                is required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
                               type: string
                             volumeName:
-                              description: VolumeName is the binding reference to
-                                the PersistentVolume backing this claim.
                               type: string
                           type: object
                         status:
-                          description: 'Status represents the current information/status
-                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             accessModes:
-                              description: 'AccessModes contains the actual access
-                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
@@ -4959,42 +2392,23 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Represents the actual resources of the
-                                underlying volume.
                               type: object
                             conditions:
-                              description: Current Condition of persistent volume
-                                claim. If underlying persistent volume is being resized
-                                then the Condition will be set to 'ResizeStarted'.
                               items:
-                                description: PersistentVolumeClaimCondition contails
-                                  details about state of pvc
                                 properties:
                                   lastProbeTime:
-                                    description: Last time we probed the condition.
                                     format: date-time
                                     type: string
                                   lastTransitionTime:
-                                    description: Last time the condition transitioned
-                                      from one status to another.
                                     format: date-time
                                     type: string
                                   message:
-                                    description: Human-readable message indicating
-                                      details about last transition.
                                     type: string
                                   reason:
-                                    description: Unique, this should be a short, machine
-                                      understandable string that gives the reason
-                                      for condition's last transition. If it reports
-                                      "ResizeStarted" that means the underlying persistent
-                                      volume is being resized.
                                     type: string
                                   status:
                                     type: string
                                   type:
-                                    description: PersistentVolumeClaimConditionType
-                                      is a valid value of PersistentVolumeClaimCondition.Type
                                     type: string
                                 required:
                                 - status
@@ -5002,7 +2416,6 @@ spec:
                                 type: object
                               type: array
                             phase:
-                              description: Phase represents the current phase of PersistentVolumeClaim.
                               type: string
                           type: object
                       type: object
@@ -5017,27 +2430,18 @@ spec:
             - refs
             type: object
           status:
-            description: IntegrationJobStatus defines the observed state of IntegrationJob
             properties:
               completionTime:
-                description: CompletionTime is a time when the job is completed
                 format: date-time
                 type: string
               jobs:
-                description: Jobs are status list for each Job in the IntegrationJob
                 items:
-                  description: JobStatus is a current status for each job
                   properties:
                     completionTime:
-                      description: CompletionTime is a timestamp when the job is started
                       format: date-time
                       type: string
                     containers:
-                      description: Containers is status list for each step in the
-                        job
                       items:
-                        description: StepState reports the results of running a step
-                          in a Task.
                         properties:
                           container:
                             type: string
@@ -5046,81 +2450,53 @@ spec:
                           name:
                             type: string
                           running:
-                            description: Details about a running container
                             properties:
                               startedAt:
-                                description: Time at which the container was last
-                                  (re-)started
                                 format: date-time
                                 type: string
                             type: object
                           terminated:
-                            description: Details about a terminated container
                             properties:
                               containerID:
-                                description: Container's ID in the format 'docker://<container_id>'
                                 type: string
                               exitCode:
-                                description: Exit status from the last termination
-                                  of the container
                                 format: int32
                                 type: integer
                               finishedAt:
-                                description: Time at which the container last terminated
                                 format: date-time
                                 type: string
                               message:
-                                description: Message regarding the last termination
-                                  of the container
                                 type: string
                               reason:
-                                description: (brief) reason from the last termination
-                                  of the container
                                 type: string
                               signal:
-                                description: Signal from the last termination of the
-                                  container
                                 format: int32
                                 type: integer
                               startedAt:
-                                description: Time at which previous execution of the
-                                  container started
                                 format: date-time
                                 type: string
                             required:
                             - exitCode
                             type: object
                           waiting:
-                            description: Details about a waiting container
                             properties:
                               message:
-                                description: Message regarding why the container is
-                                  not yet running.
                                 type: string
                               reason:
-                                description: (brief) reason the container is not yet
-                                  running.
                                 type: string
                             type: object
                         type: object
                       type: array
                     message:
-                      description: Message is current state description for this job
-                        It is actually tekton task run's Status.Conditions[0].Message
                       type: string
                     name:
-                      description: Name is a job name
                       type: string
                     podName:
-                      description: PodName is a name of pod where the job is running
                       type: string
                     startTime:
-                      description: StartTime is a timestamp when the job is started
                       format: date-time
                       type: string
                     state:
-                      description: State is current state of this job It is actually
-                        a conversion of tekton task run's Status.Conditions[0].Reason
                       type: string
                   required:
                   - message
@@ -5129,15 +2505,11 @@ spec:
                   type: object
                 type: array
               message:
-                description: Message is a message for the IntegrationJob (normally
-                  an error string)
                 type: string
               startTime:
-                description: StartTime is actual time the task started
                 format: date-time
                 type: string
               state:
-                description: State is a current state of the IntegrationJob
                 type: string
             required:
             - state


### PR DESCRIPTION
# Changes
Current CRDs includes openAPIV3schemaValidation, which is too long for CRDs to be applied without flags `--server-side=true`
As a workaround, modify method to generate CRD without description as well as in CI 


# Submitter Checklist
<!--
Please check the following checklist before submitting

You can check an item like:
- [x] Docs
-->

- [ ] Docs included if needed
- [ ] Tests included if needed
- [ ] Follows the [good commit messages standard](https://chris.beams.io/posts/git-commit/) 
